### PR TITLE
hotfixes

### DIFF
--- a/tests/system-tests/recovery-tests/test_dc.py
+++ b/tests/system-tests/recovery-tests/test_dc.py
@@ -119,8 +119,7 @@ def test_one_node_dc_with_indexes(client, nodes, write_indexes_when_groups_dropp
     recovered_keys = []
     for node in test_nodes:
         cmd = ["dnet_recovery",
-               "--remote", "{0}:{1}:2".format(node.host, node.port),
-               "--one-node",
+               "--one-node", "{0}:{1}:2".format(node.host, node.port),
                "--groups", ','.join(map(str, client.groups)),
                "dc"]
         logger.info("{0}\n".format(cmd))

--- a/tests/system-tests/recovery-tests/test_dc.py
+++ b/tests/system-tests/recovery-tests/test_dc.py
@@ -123,7 +123,8 @@ def test_one_node_dc_with_indexes(client, nodes, write_indexes_when_groups_dropp
                "--groups", ','.join(map(str, client.groups)),
                "dc"]
         logger.info("{0}\n".format(cmd))
-        subprocess.call(cmd)
+        retcode = subprocess.call(cmd)
+        assert retcode == 0, "{0} retcode = {1}".format(cmd, retcode)
 
         for k, v in bad_keys.items():
             elliptics_id = client.transform(k)
@@ -187,7 +188,8 @@ def test_dc_with_indexes(client, nodes, write_indexes_when_groups_dropped):
            "--groups", ','.join(map(str, client.groups)),
            "dc"]
     logger.info("{0}\n".format(cmd))
-    subprocess.call(cmd)
+    retcode = subprocess.call(cmd)
+    assert retcode == 0, "{0} retcode = {1}".format(cmd, retcode)
 
     for k, v in bad_keys.items():
         good_keys[k].extend(v)
@@ -238,7 +240,8 @@ def test_nprocess_dc_with_indexes(client, nodes, write_indexes_when_groups_dropp
            "--groups", ','.join(map(str, client.groups)),
            "dc"]
     logger.info("{0}\n".format(cmd))
-    subprocess.call(cmd)
+    retcode = subprocess.call(cmd)
+    assert retcode == 0, "{0} retcode = {1}".format(cmd, retcode)
 
     for k, v in bad_keys.items():
         good_keys[k].extend(v)

--- a/tests/system-tests/recovery-tests/test_merge.py
+++ b/tests/system-tests/recovery-tests/test_merge.py
@@ -114,7 +114,8 @@ def test_one_node_option(client, nodes, write_data_when_two_dropped):
                "merge"]
 
         logger.info("{0}\n".format(cmd))
-        subprocess.call(cmd)
+        retcode = subprocess.call(cmd)
+        assert retcode == 0, "{0} retcode = {1}".format(cmd, retcode)
 
         key_list = []
         for k in bad_key_list:
@@ -166,7 +167,8 @@ def test_merge_add_two_nodes(client, nodes, write_data_when_two_dropped):
            "--groups", ','.join(map(str, client.groups)),
            "merge"]
     logger.info("{0}\n".format(cmd))
-    subprocess.call(cmd)
+    retcode = subprocess.call(cmd)
+    assert retcode == 0, "{0} retcode = {1}".format(cmd, retcode)
 
     # check all keys and data
     good_keys_list = [k for v in good_keys.values() for k in v]

--- a/tests/system-tests/recovery-tests/test_merge.py
+++ b/tests/system-tests/recovery-tests/test_merge.py
@@ -147,7 +147,7 @@ def test_merge_add_two_nodes(client, nodes, write_data_when_two_dropped):
     """Tests that 'dnet_recovery --remote ... merge'
     will recover all keys when there were 2 dropped nodes
     """
-    good_keys, bad_keys, dropped_nodes, dropped_ring_partitioning = write_data_when_two_dropped
+    good_keys, bad_keys, dropped_nodes, _ = write_data_when_two_dropped
 
     # check that "good" keys are accessible
     for key_list in good_keys.values():

--- a/tests/system-tests/recovery-tests/test_merge.py
+++ b/tests/system-tests/recovery-tests/test_merge.py
@@ -146,7 +146,7 @@ def test_merge_add_two_nodes(client, nodes, write_data_when_two_dropped):
     """Tests that 'dnet_recovery --remote ... merge'
     will recover all keys when there were 2 dropped nodes
     """
-    good_keys, bad_keys, dropped_nodes = write_data_when_two_dropped
+    good_keys, bad_keys, dropped_nodes, dropped_ring_partitioning = write_data_when_two_dropped
 
     # check that "good" keys are accessible
     for key_list in good_keys.values():


### PR DESCRIPTION
1. Поправил тесты восстановления с новой версией **dnet_recovery**: ей теперь нужно педеравать ноду, для опции `--one-node`.
2. Пофиксил тесты, чтобы они теперь смотрели на код возврата dnet_recovery - она теперь стабильно падает, при ошибках, на наших тестах.

Посмотри, пожалуйста, @uvizhe
