### PR TITLE
testenv: unstable cluster preparation scripts were added

### DIFF
--- a/ansible/group_vars/unstable.json
+++ b/ansible/group_vars/unstable.json
@@ -1,0 +1,8 @@
+{
+  "prepared_elliptics_dir": "/opt/prepared_elliptics_testing",
+  "elliptics_dir": "/opt/elliptics_testing",
+  "log_dir": "log",
+  "data_dir": "data",
+  "hist_dir": "history",
+  "conf_dir": "configs"
+}

--- a/ansible/roles/install-elliptics-from-repo/tasks/main.yml
+++ b/ansible/roles/install-elliptics-from-repo/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install Elliptics packages
   shell: >
+    sudo
     apt-get
     install
     --assume-yes

--- a/ansible/templates/unstable_elliptics.json.j2
+++ b/ansible/templates/unstable_elliptics.json.j2
@@ -1,0 +1,47 @@
+{
+  "loggers": {
+    "type": "{{ elliptics_dir }}/{{ log_dir }}/{{ item }}/elliptics.log",
+    "level": 4
+  },
+  "options": {
+    "join": true,
+    "remote": [
+      {% for host in groups['servers'] %}
+        {% for n in nodes %}
+          "{{ host }}:{{ 1025 + n - 1 }}:2"
+          {% if not loop.last %}
+          ,
+          {% endif %}
+        {% endfor %}
+        {% if not loop.last %}
+          ,
+        {% endif %}
+      {% endfor %}
+    ],
+    "address": [
+      "{{ ansible_eth0.ipv4.address }}:{{ 1025 + item - 1 }}:2"
+    ],
+    "wait_timeout": 30,
+    "check_timeout": 50,
+    "io_thread_num": 8,
+    "nonblocking_io_thread_num": 8,
+    "net_thread_num": 4,
+    "daemon": true,
+    "auth_cookie": "ellicoca",
+    "cache": {
+      "size": 0
+    }
+  },
+  "backends": [
+    {
+      "type": "blob",
+      "group": {{ group }},
+      "history": "{{ elliptics_dir }}/{{ hist_dir }}/{{ item }}",
+      "data": "{{ elliptics_dir }}/{{ data_dir }}/{{ item }}/data",
+      "sync": 300,
+      "blob_size": "20G",
+      "blob_flags": 64,
+      "records_in_blob": 10000000
+    }
+  ]
+}

--- a/ansible/unstable-cluster-prepare.yml
+++ b/ansible/unstable-cluster-prepare.yml
@@ -1,0 +1,47 @@
+---
+- hosts: all
+  sudo: yes
+  tasks:
+    - name: Perform 'apt-get update'
+      apt: update_cache=yes
+
+- hosts: all
+  roles:
+    - install-elliptics-from-repo
+
+- hosts: servers
+  sudo: yes
+  vars:
+    nodes: [1, 2, 3]
+  tasks:
+    - name: Create necessary directories
+      file:
+        path={{ elliptics_dir }}/{{ item[0] }}/{{ item[1] }}
+        state=directory
+      with_nested:
+        - ["{{ log_dir }}", "{{ data_dir }}", "{{ hist_dir }}", "{{ conf_dir }}"]
+        - nodes
+
+    - name: Copy prepared data
+      shell: cp -r {{ prepared_elliptics_dir }}/. {{ elliptics_dir }}
+      ignore_errors: yes
+
+    - name: Create Elliptics config file
+      template:
+        src=templates/unstable_elliptics.json.j2
+        dest={{ elliptics_dir }}/{{ conf_dir }}/{{ item }}/node.json
+      with_items: nodes
+
+    - name: Start Elliptics daemon
+      command: dnet_ioserv -c {{ elliptics_dir }}/{{ conf_dir }}/{{ item }}/node.json
+      with_items: nodes
+
+    - name: Wait for Elliptics to start up
+      pause: seconds=10
+
+    - name: Get id of all Elliptics processes
+      shell: pgrep dnet_ioserv
+      register: pgrep
+
+    - name: Check that all Elliptics processes is running
+      shell: "[ {{ pgrep.stdout.splitlines()|length }} -eq {{ nodes|length }} ]"

--- a/ansible/unstable-cluster-wipe-out.yml
+++ b/ansible/unstable-cluster-wipe-out.yml
@@ -1,0 +1,19 @@
+---
+- hosts: servers
+  sudo: yes
+  tasks:
+    - name: Getting process id
+      shell: pgrep dnet_ioserv
+      register: pgrep
+      ignore_errors: yes
+
+    - name: Stop Elliptics
+      shell: kill {{ item }}
+      with_items: pgrep.stdout.splitlines()
+
+    - name: Wait for Elliptics to stop
+      shell: while [ -e /proc/{{ item }} ]; do sleep 0.1; done
+      with_items: pgrep.stdout.splitlines()
+
+    - name: Wipe out elliptics artifacts
+      file: path={{ elliptics_dir }} state=absent

--- a/ansible/unstable-cluster.hosts
+++ b/ansible/unstable-cluster.hosts
@@ -1,0 +1,20 @@
+[clients]
+s14h.xxx.yandex.net ansible_ssh_user=buildfarm
+
+[servers-1]
+s16h.xxx.yandex.net ansible_ssh_user=buildfarm
+
+[servers-2]
+s17h.xxx.yandex.net ansible_ssh_user=buildfarm
+
+[servers-3]
+s18h.xxx.yandex.net ansible_ssh_user=buildfarm
+
+[servers:children]
+servers-1
+servers-2
+servers-3
+
+[unstable:children]
+servers
+clients

--- a/lib/test_helper/elliptics_testhelper.py
+++ b/lib/test_helper/elliptics_testhelper.py
@@ -148,7 +148,7 @@ class EllipticsTestHelper(elliptics.Session):
                                                                        rule=rule)
             subprocess.call(shlex.split(cmd))
             print(cmd)
-            self.dropped_nodes.append(node)
+        self.dropped_nodes.append(node)
 
     def resume_node(self, node):
         """ Unlocks a node for elliptics requests
@@ -158,13 +158,14 @@ class EllipticsTestHelper(elliptics.Session):
             cmd = "ssh -q root@{host} iptables --delete {rule}".format(host=node.host,
                                                                        rule=rule)
             subprocess.call(shlex.split(cmd))
-            self.dropped_nodes.remove(node)
+            print(cmd)
 
     def resume_all_nodes(self):
         """ Unlocks all nodes for elliptics requests
         """
         for node in self.dropped_nodes:
             self.resume_node(node)
+        self.dropped_nodes = []
 
     # Synchronous versions for Elliptics commands
     def write_data_sync(self, key, data, offset=0, chunk_size=0):


### PR DESCRIPTION
Добавил скрипты для подготовки тестов на железных машинках.
Будет запускаться скрипт удаления данных от прошлого прогона и затем скрипт для поднятия Эллиптикса. После этого можно запускать тест.

Сделал отдельный шаблон для конфига, так как в будущем скрипт поднятия Эллиптикса, вероятно будет один, и можно будет совместить это все: один шаблон с множеством параметров (для теста на железных машинках он будет задан в `group_vars/unstable.json`) и сценарии поднятия/остановки Эллиптикса. А сейчас не хотел перенагружать имеющийся конфиг новой логикой (пришлось бы менять и сценарий поднятия Эллиптикса) - хочется сделать это отдельно, если мы захотим объединить это все.

Примечание: отдельный коммит с **sudo** это чтобы использовать установку пакетов в новом сценарии (со старым будет так же работать); правка для drop/resume - это фикс моей баги, без этого, когда я генерирую данные скриптом (который будет попозже) были проблемы и нужно было еще ручками править фильтры для фаервола.

reviewers: @uvizhe, @tIGO
