### PR TITLE
fix: for missing option - to be able to downgrade packages

### DIFF
--- a/ansible/roles/install-elliptics-from-repo/tasks/main.yml
+++ b/ansible/roles/install-elliptics-from-repo/tasks/main.yml
@@ -4,6 +4,7 @@
     apt-get
     install
     --assume-yes
+    --force-yes
     elliptics={{ elliptics_version }}
     elliptics-client={{ elliptics_version }}
     eblob={{ eblob_version }}


### PR DESCRIPTION
Так можно будет делать downgrade пакетов, когда используешь скрипты подготовки тестового окружения вручную.

reviewers: @uvizhe
