### PR TITLE
tests: test for dnet_recovery with --dump-file option was added

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import pytest
+import os.path
+import elliptics
+
+from test_helper.elliptics_testhelper import nodes
+
+
+def pytest_addoption(parser):
+    parser.addoption('--node', type='string', action='append', dest="nodes",
+                     help="Elliptics node. Example: --node=hostname:port:group")
+    parser.addoption('--wait-timeout', type='int', dest="wait_timeout",
+                     help="Elliptics wait_timeout.")
+    parser.addoption('--check-timeout', type='int', dest="check_timeout",
+                     help="Elliptics check_timeout.")
+    parser.addoption('--logging-level', type='int', dest="logging_level", default=4,
+                     help="Elliptics logging_level.")
+
+
+@pytest.fixture(scope='module')
+def session(pytestconfig, nodes):
+    """Returns prepared elliptics.Session."""
+    if pytestconfig.option.logging_level:
+        log_path = "/var/log/elliptics/client.log"
+        dir_path = os.path.dirname(log_path)
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+        elog = elliptics.Logger(log_path, pytestconfig.option.logging_level)
+    else:
+        elog = elliptics.Logger("/dev/stderr", pytestconfig.option.logging_level)
+
+    config = elliptics.Config()
+    if pytestconfig.option.wait_timeout:
+        config.wait_timeout = pytestconfig.option.wait_timeout
+    if pytestconfig.option.check_timeout:
+        config.check_timeout = pytestconfig.option.check_timeout
+
+    client_node = elliptics.Node(elog, config)
+    for node in nodes:
+        client_node.add_remote(node.host, node.port)
+
+    elliptics_session = elliptics.Session(client_node)
+
+    # Get uniq groups from nodes list
+    groups = list({n.group for n in nodes})
+    elliptics_session.groups = groups
+
+    return elliptics_session

--- a/tests/functional-tests/indexes-tests/conftest.py
+++ b/tests/functional-tests/indexes-tests/conftest.py
@@ -1,4 +1,3 @@
 def pytest_addoption(parser):
-    parser.addoption('--node', action='append', dest="nodes")
     parser.addoption('--batches-number', type='int', dest="batches_number", default=100)
     parser.addoption('--files-per-batch', type='int', dest="files_per_batch", default=1000)

--- a/tests/functional-tests/read-write-tests/conftest.py
+++ b/tests/functional-tests/read-write-tests/conftest.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-#
-#TODO: replace Exception with a proper exception class from elliptics module
-def pytest_addoption(parser):
-    parser.addoption('--node', type='string', action='append', dest="nodes")

--- a/tests/system-tests/big-rwtest/conftest.py
+++ b/tests/system-tests/big-rwtest/conftest.py
@@ -3,4 +3,4 @@ def pytest_addoption(parser):
     parser.addoption('--batch_size', type='int', default='50')
     parser.addoption('--check_timeout', type='int', default='60')
     parser.addoption('--wait_timeout', type='int', default='50')
-    parser.addoption('--node', type='string', dest="nodes", action='append')
+

--- a/tests/system-tests/cache-tests/conftest.py
+++ b/tests/system-tests/cache-tests/conftest.py
@@ -6,10 +6,6 @@ import test_helper.elliptics_testhelper as et
 from test_helper.elliptics_testhelper import nodes
 
 
-def pytest_addoption(parser):
-    parser.addoption('--node', type='string', action='append', dest="nodes")
-
-
 @pytest.fixture(scope='function')
 def client(pytestconfig, nodes):
     """Prepares elliptics.Session object with elliptics.io_flags.cache."""

--- a/tests/system-tests/different-versions/conftest.py
+++ b/tests/system-tests/different-versions/conftest.py
@@ -1,7 +1,6 @@
 import apt
 
 def pytest_addoption(parser):
-    parser.addoption("--node", action="append", dest="nodes")
     parser.addoption("--old-version", dest="old_version")
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/system-tests/recovery-tests/conftest.py
+++ b/tests/system-tests/recovery-tests/conftest.py
@@ -67,5 +67,3 @@ def pytest_addoption(parser):
                      help="Amount of files to write.")
     parser.addoption('--files_size', type='int', default=0,
                      help="Amount of bytes for a single file.")
-    parser.addoption('--node', type='string', action='append', dest="nodes",
-                     help="Elliptics node. Example: --node=hostname:port:group")

--- a/tests/timeouts-tests/conftest.py
+++ b/tests/timeouts-tests/conftest.py
@@ -4,4 +4,3 @@
 def pytest_addoption(parser):
     parser.addoption('--wait_timeout', type='int')
     parser.addoption('--check_timeout', type='int')
-    parser.addoption('--node', type='string', action='append', dest="nodes")

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -9,8 +9,6 @@ def pytest_addoption(parser):
                      "and will not be recovered.")
     parser.addoption('--files-size', type='int', default=0, dest="files_size",
                      help="Amount of bytes for a single file.")
-    parser.addoption('--node', type='string', action='append', dest="nodes",
-                     help="Elliptics node. Example: --node=hostname:port:group")
     parser.addoption('--good-keys-path', dest="good_keys_path",
                      help="Path to a file with a list of good keys (in JSON format).")
     parser.addoption('--bad-keys-path', dest="bad_keys_path",

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -1,0 +1,17 @@
+def pytest_addoption(parser):
+    parser.addoption('--good-files-number', type='int', default='127', dest="good_files_number",
+                     help="Amount of files to write which will be accessible from all groups.")
+    parser.addoption('--bad-files-number', type='int', default='256', dest="bad_files_number",
+                     help="Amount of files to write which will be accessible from some groups "
+                     "and will be recovered.")
+    parser.addoption('--broken-files-number', type='int', default='127', dest="broken_files_number",
+                     help="Amount of files to write which will be accessible from some groups "
+                     "and will not be recovered.")
+    parser.addoption('--files-size', type='int', default=0, dest="files_size",
+                     help="Amount of bytes for a single file.")
+    parser.addoption('--node', type='string', action='append', dest="nodes",
+                     help="Elliptics node. Example: --node=hostname:port:group")
+    parser.addoption('--good-keys-path', dest="good_keys_path")
+    parser.addoption('--bad-keys-path', dest="bad_keys_path")
+    parser.addoption('--broken-keys-path', dest="broken_keys_path")
+    parser.addoption('--dropped-groups', dest="dropped_groups")

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -11,7 +11,12 @@ def pytest_addoption(parser):
                      help="Amount of bytes for a single file.")
     parser.addoption('--node', type='string', action='append', dest="nodes",
                      help="Elliptics node. Example: --node=hostname:port:group")
-    parser.addoption('--good-keys-path', dest="good_keys_path")
-    parser.addoption('--bad-keys-path', dest="bad_keys_path")
-    parser.addoption('--broken-keys-path', dest="broken_keys_path")
-    parser.addoption('--dropped-groups', dest="dropped_groups")
+    parser.addoption('--good-keys-path', dest="good_keys_path",
+                     help="Path to a file with a list of good keys (in JSON format).")
+    parser.addoption('--bad-keys-path', dest="bad_keys_path",
+                     help="Path to a file with a list of bad keys (in JSON format).")
+    parser.addoption('--broken-keys-path', dest="broken_keys_path",
+                     help="Path to a file with a list of broken keys (in JSON format).")
+    parser.addoption('--dropped-groups', dest="dropped_groups",
+                     help="Path to a file with a list of elliptics groups where bad keys "
+                     "will be recovered (in JSON format).")

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -192,7 +192,7 @@ def test_dump_file(client, nodes, good_keys, bad_keys, broken_keys, dropped_grou
         for g in client.groups:
             result = client.read_data_from_groups(k, [g]).get()[0]
             result_data_hash = get_sha1(result.data)
-            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
+            assert_that(k, described_as("After recovering the data mismatch by sha1 hash: %0",
                                         equal_to(result_data_hash),
                                         result_data_hash))
 
@@ -202,7 +202,7 @@ def test_dump_file(client, nodes, good_keys, bad_keys, broken_keys, dropped_grou
         for g in available_groups:
             result = client.read_data_from_groups(k, [g]).get()[0]
             result_data_hash = get_sha1(result.data)
-            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
+            assert_that(k, described_as("After recovering the data mismatch by sha1 hash: %0",
                                         equal_to(result_data_hash),
                                         result_data_hash))
 

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -122,49 +122,35 @@ def good_keys(pytestconfig, client):
 
 
 @pytest.fixture(scope='function')
-def bad_keys(request, pytestconfig, client, dropped_groups):
+def bad_keys(pytestconfig, client, dropped_groups):
     """Returns list of "bad" keys."""
-    full_groups_list = client.groups
-
     if pytestconfig.option.bad_keys_path:
         bad_keys = json.load(open(pytestconfig.option.bad_keys_path))
         bad_keys = [str(k) for k in bad_keys]
     else:
+        restricted_client = client.clone()
         # "Bad" keys will be written in all groups except groups from dropped_groups
-        client.set_groups([g for g in full_groups_list if g not in dropped_groups])
-        bad_keys = write_files(client,
+        restricted_client.set_groups([g for g in restricted_client.groups if g not in dropped_groups])
+        bad_keys = write_files(restricted_client,
                                pytestconfig.option.bad_files_number,
                                pytestconfig.option.files_size)
-
-    def fin():
-        """Restores client's groups."""
-        client.set_groups(full_groups_list)
-
-    request.addfinalizer(fin)
 
     return bad_keys
 
 
 @pytest.fixture(scope='function')
-def broken_keys(request, pytestconfig, client, dropped_groups):
+def broken_keys(pytestconfig, client, dropped_groups):
     """Returns list of "broken" keys."""
-    full_groups_list = client.groups
-
     if pytestconfig.option.broken_keys_path:
         broken_keys = json.load(open(pytestconfig.option.broken_keys_path))
         broken_keys = [str(k) for k in broken_keys]
     else:
+        restricted_client = client.clone()
         # "Broken" keys will be written in all groups except groups from dropped_groups
-        client.set_groups([g for g in full_groups_list if g not in dropped_groups])
-        broken_keys = write_files(client,
+        restricted_client.set_groups([g for g in restricted_client.groups if g not in dropped_groups])
+        broken_keys = write_files(restricted_client,
                                   pytestconfig.option.broken_files_number,
                                   pytestconfig.option.files_size)
-
-    def fin():
-        """Restores client's groups."""
-        client.set_groups(full_groups_list)
-
-    request.addfinalizer(fin)
 
     return broken_keys
 

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -176,29 +176,23 @@ def test_dump_file(session, nodes, good_keys, bad_keys, broken_keys, dropped_gro
     for k in bad_keys:
         for g in session.groups:
             result = session.read_data_from_groups(k, [g]).get()[0]
-            result_data_hash = get_sha1(result.data)
-            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
-                                        equal_to(result_data_hash),
-                                        result_data_hash))
+            assert_that(k, equal_to(get_sha1(result.data)),
+                        "The recovered data mismatch by sha1 hash")
 
     logger.info('Checking "good" keys...\n')
     for k in good_keys:
         for g in session.groups:
             result = session.read_data_from_groups(k, [g]).get()[0]
-            result_data_hash = get_sha1(result.data)
-            assert_that(k, described_as("After recovering the data mismatch by sha1 hash: %0",
-                                        equal_to(result_data_hash),
-                                        result_data_hash))
+            assert_that(k, equal_to(get_sha1(result.data)),
+                        "After recovering the data mismatch by sha1 hash")
 
     logger.info('Check "broken" keys...\n')
     available_groups = [g for g in session.groups if g not in dropped_groups]
     for k in broken_keys:
         for g in available_groups:
             result = session.read_data_from_groups(k, [g]).get()[0]
-            result_data_hash = get_sha1(result.data)
-            assert_that(k, described_as("After recovering the data mismatch by sha1 hash: %0",
-                                        equal_to(result_data_hash),
-                                        result_data_hash))
+            assert_that(k, equal_to(get_sha1(result.data)),
+                        "After recovering the data mismatch by sha1 hash")
 
     for k in broken_keys:
         for g in dropped_groups:

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -59,7 +59,7 @@ import subprocess
 import random
 import json
 
-from hamcrest import assert_that, raises, calling, equal_to
+from hamcrest import assert_that, raises, calling, equal_to, described_as
 
 from test_helper.elliptics_testhelper import EllipticsTestHelper, nodes
 from test_helper.utils import get_sha1, get_key_and_data
@@ -196,20 +196,29 @@ def test_dump_file(client, nodes, good_keys, bad_keys, broken_keys, dropped_grou
     for k in bad_keys:
         for g in client.groups:
             result = client.read_data_from_groups_sync(k, [g])[0]
-            assert_that(k, equal_to(get_sha1(result.data)))
+            result_data_hash = get_sha1(result.data)
+            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
+                                        equal_to(result_data_hash),
+                                        result_data_hash))
 
     logger.info('Checking "good" keys...\n')
     for k in good_keys:
         for g in client.groups:
             result = client.read_data_from_groups_sync(k, [g])[0]
-            assert_that(k, equal_to(get_sha1(result.data)))
+            result_data_hash = get_sha1(result.data)
+            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
+                                        equal_to(result_data_hash),
+                                        result_data_hash))
 
     logger.info('Check "broken" keys...\n')
     available_groups = [g for g in client.groups if g not in dropped_groups]
     for k in broken_keys:
         for g in available_groups:
             result = client.read_data_from_groups_sync(k, [g])[0]
-            assert_that(k, equal_to(get_sha1(result.data)))
+            result_data_hash = get_sha1(result.data)
+            assert_that(k, described_as("The recovered data mismatch by sha1 hash: %0",
+                                        equal_to(result_data_hash),
+                                        result_data_hash))
 
     for k in broken_keys:
         for g in dropped_groups:

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -1,3 +1,58 @@
+"""Elliptics dc recovery tests.
+
+These tests are testing dc recovery for elliptics recovery script (`dnet_recovery`).
+Tests are using following types of keys:
+
+* good keys (accessible from all groups);
+* bad keys (accessible from several groups and will be recovered);
+* broken keys (accessible from several groups and will not be recovered).
+
+Running tests
+-------------
+
+The tests split up their functionality into two ways to run:
+
+1. Run tests when they will prepare all data on the run.
+1. Specify files with information about prepared data.
+
+Example of running tests with data preparation on the run (for more information
+see `py.test --help`):
+
+    PYTHONPATH=./lib py.test -v -s \
+    --node=server-1:1025:1 \
+    --node=server-1:1026:1 \
+    --node=server-1:1027:1 \
+    --node=server-2:1025:2 \
+    --node=server-2:1026:2 \
+    --node=server-2:1027:2 \
+    --node=server-3:1025:3 \
+    --node=server-3:1026:3 \
+    --node=server-3:1027:3 \
+    --good-files-number=70 \
+    --bad-files-number=100 \
+    --broken-files-number=50 \
+    --files-size=102400 \
+    tests/unstable/
+
+Example of running tests with prepared files with information about written data:
+
+    PYTHONPATH=./lib py.test -v -s \
+    --node=server-1:1025:1 \
+    --node=server-1:1026:1 \
+    --node=server-1:1027:1 \
+    --node=server-2:1025:2 \
+    --node=server-2:1026:2 \
+    --node=server-2:1027:2 \
+    --node=server-3:1025:3 \
+    --node=server-3:1026:3 \
+    --node=server-3:1027:3 \
+    --good-keys-path=./good_keys \
+    --bad-keys-path=./bad_keys \
+    --broken-keys-path=./broken_keys \
+    tests/unstable/
+
+"""
+
 import pytest
 import elliptics
 import subprocess
@@ -9,6 +64,7 @@ from hamcrest import assert_that, raises, calling, equal_to
 from test_helper.elliptics_testhelper import EllipticsTestHelper, nodes
 from test_helper.utils import get_sha1, get_key_and_data
 from test_helper.logging_tests import logger
+
 
 @pytest.fixture(scope='module')
 def client(nodes):
@@ -124,6 +180,7 @@ def dump_file(client, bad_keys):
 
 
 def test_dump_file(client, nodes, good_keys, bad_keys, broken_keys, dropped_groups, dump_file):
+    """Testing `dnet_recovery` with `--dump-file` option."""
     node = random.choice(nodes)
     cmd = ["dnet_recovery",
            "--remote", "{}:{}:2".format(node.host, node.port),

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -1,0 +1,160 @@
+import pytest
+import elliptics
+import subprocess
+import random
+import json
+
+from hamcrest import assert_that, raises, calling, equal_to
+
+from test_helper.elliptics_testhelper import EllipticsTestHelper, nodes
+from test_helper.utils import get_sha1, get_key_and_data
+from test_helper.logging_tests import logger
+
+@pytest.fixture(scope='module')
+def client(nodes):
+    """Prepares elliptics session with long timeouts."""
+    client = EllipticsTestHelper(nodes=nodes, wait_timeout=25, check_timeout=30, logging_level=0)
+    return client
+
+
+def write_files(client, files_number, file_size):
+    """Writes files with preset client and specified files parameters: numbers and size."""
+    logger.info("Started writing {0} files\n".format(files_number))
+
+    key_list = []
+    for i in xrange(files_number):
+        key, data = get_key_and_data(file_size, randomize_len=False)
+
+        client.write_data_sync(key, data)
+        key_list.append(key)
+        logger.info("\r{0}/{1}".format(i + 1, files_number))
+
+    logger.info("\nFinished writing files\n")
+
+    return key_list
+
+
+@pytest.fixture(scope='module')
+def dropped_groups(pytestconfig, client):
+    """Returns a list of dropped groups.
+
+    There are only "good" keys will be accessible in these groups.
+    "Bad" and "broken" keys will not be written to them.
+
+    """
+    if pytestconfig.option.dropped_groups:
+        groups = json.load(open(pytestconfig.option.dropped_groups))
+    else:
+        groups_count = len(client.groups)
+        dropped_groups_count = (groups_count + 1) / 2
+        groups = random.sample(client.groups, dropped_groups_count)
+
+    return groups
+
+
+@pytest.fixture(scope='function')
+def good_keys(pytestconfig, client):
+    """Returns list of "good" keys."""
+    if pytestconfig.option.good_keys_path:
+        good_keys = json.load(open(pytestconfig.option.good_keys_path))
+        good_keys = [str(k) for k in good_keys]
+    else:
+        good_keys = write_files(client,
+                                pytestconfig.option.good_files_number,
+                                pytestconfig.option.files_size)
+    return good_keys
+
+
+@pytest.fixture(scope='function')
+def bad_keys(request, pytestconfig, client, dropped_groups):
+    """Returns list of "bad" keys."""
+    full_groups_list = client.groups
+
+    if pytestconfig.option.bad_keys_path:
+        bad_keys = json.load(open(pytestconfig.option.bad_keys_path))
+        bad_keys = [str(k) for k in bad_keys]
+    else:
+        # "Bad" keys will be written in all groups except groups from dropped_groups
+        client.set_groups([g for g in full_groups_list if g not in dropped_groups])
+        bad_keys = write_files(client,
+                               pytestconfig.option.bad_files_number,
+                               pytestconfig.option.files_size)
+
+    def fin():
+        """Restores client's groups."""
+        client.set_groups(full_groups_list)
+
+    request.addfinalizer(fin)
+
+    return bad_keys
+
+
+@pytest.fixture(scope='function')
+def broken_keys(request, pytestconfig, client, dropped_groups):
+    """Returns list of "broken" keys."""
+    full_groups_list = client.groups
+
+    if pytestconfig.option.broken_keys_path:
+        broken_keys = json.load(open(pytestconfig.option.broken_keys_path))
+        broken_keys = [str(k) for k in broken_keys]
+    else:
+        # "Broken" keys will be written in all groups except groups from dropped_groups
+        client.set_groups([g for g in full_groups_list if g not in dropped_groups])
+        broken_keys = write_files(client,
+                                  pytestconfig.option.broken_files_number,
+                                  pytestconfig.option.files_size)
+
+    def fin():
+        """Restores client's groups."""
+        client.set_groups(full_groups_list)
+
+    request.addfinalizer(fin)
+
+    return broken_keys
+
+
+@pytest.fixture(scope='function')
+def dump_file(client, bad_keys):
+    """Writes id of keys to a dump file and returns the file name."""
+    ids = [str(client.transform(k)) for k in bad_keys]
+    file_name = "id_dump"
+    with open(file_name, "w") as f:
+        f.write("\n".join(ids))
+    return file_name
+
+
+def test_dump_file(client, nodes, good_keys, bad_keys, broken_keys, dropped_groups, dump_file):
+    node = random.choice(nodes)
+    cmd = ["dnet_recovery",
+           "--remote", "{}:{}:2".format(node.host, node.port),
+           "--groups", ','.join([str(g) for g in client.groups]),
+           "--dump-file", dump_file,
+           "dc"]
+    logger.info("{}\n".format(cmd))
+
+    retcode = subprocess.call(cmd)
+    assert retcode == 0, "{} retcode = {}".format(cmd, retcode)
+
+    logger.info('Checking recovered keys...\n')
+    for k in bad_keys:
+        for g in client.groups:
+            result = client.read_data_from_groups_sync(k, [g])[0]
+            assert_that(k, equal_to(get_sha1(result.data)))
+
+    logger.info('Checking "good" keys...\n')
+    for k in good_keys:
+        for g in client.groups:
+            result = client.read_data_from_groups_sync(k, [g])[0]
+            assert_that(k, equal_to(get_sha1(result.data)))
+
+    logger.info('Check "broken" keys...\n')
+    available_groups = [g for g in client.groups if g not in dropped_groups]
+    for k in broken_keys:
+        for g in available_groups:
+            result = client.read_data_from_groups_sync(k, [g])[0]
+            assert_that(k, equal_to(get_sha1(result.data)))
+
+    for k in broken_keys:
+        for g in dropped_groups:
+            assert_that(calling(client.read_data_from_groups_sync).with_args(k, [g]),
+                        raises(elliptics.NotFoundError))


### PR DESCRIPTION
Это тест восстановления с опцией `--dump-file`.

Я сделал в отдельном файле, чтобы можно было посмотреть на изменения, которые затронут все тесты восстановления, чтобы запускать их двумя способами:
1. когда тесты сами записывают для себя данные;
2. когда тесты принимают файлы, в которые указаны, какие данные были записаны (для тестов на большом объеме данных).

Тесты можно запустить (подробности в **conftest.py** или `py.test --help`, находясь в `tests/unstable/`):

1)

```
PYTHONPATH=./ py.test -v -s \
--node=server-1:1025:1 \
--node=server-1:1026:1 \
--node=server-1:1027:1 \
--node=server-2:1025:2 \
--node=server-2:1026:2 \
--node=server-2:1027:2 \
--node=server-3:1025:3 \
--node=server-3:1026:3 \
--node=server-3:1027:3 \
--good-files-number=70 \
--bad-files-number=100 \
--broken-files-number=50 \
--files-size=102400 \
tests/unstable/
```

2)

```
PYTHONPATH=./ py.test -v -s \
--node=server-1:1025:1 \
--node=server-1:1026:1 \
--node=server-1:1027:1 \
--node=server-2:1025:2 \
--node=server-2:1026:2 \
--node=server-2:1027:2 \
--node=server-3:1025:3 \
--node=server-3:1026:3 \
--node=server-3:1027:3 \
--good-keys-path=./good_keys \
--bad-keys-path=./bad_keys \
--broken-keys-path=./broken_keys \
tests/unstable/
```

Сейчас предполагаю слить эти изменения в **develop** и сделать активным билд тестирования на реальном кластере (это возможно, так как этот тест в отдельном файле).
И после этого приступлю к изменению остальных тестов восстановления, допиливанию запускатора, чтобы он мог работать с реальными машинками.

reviewers: @uvizhe, @shaitan
