### PR TITLE
fix: outdated test was excluded

### DIFF
--- a/configs/system-tests/test_different-versions.cfg
+++ b/configs/system-tests/test_different-versions.cfg
@@ -16,5 +16,5 @@
 	"setup_playbook": "tests/setup-different-versions-test",
 	"teardown_playbook": "tests/teardown-different-versions-test"
         },
-    "tags": ["system", "different-versions", "testing-packages", "pull-request"]
+    "tags": ["system", "different-versions"]
 }


### PR DESCRIPTION
Исключил тесты разных версий - их нужно обновить (сейчас они ломают тестовый стенд после появления новой версии eblob'а, несовместимой со старыми версиями).

reviewers: @uvizhe
