### PR TITLE
recovery tests with indexes

### DIFF
--- a/lib/test_helper/matchers.py
+++ b/lib/test_helper/matchers.py
@@ -61,3 +61,24 @@ class HasItems(BaseMatcher):
 def hasitems(*elements):
     """Custom has_items matcher with a short description."""
     return HasItems(*elements)
+
+
+class HasItem(BaseMatcher):
+    def __init__(self, element):
+        self.element = element
+
+    def matches(self, item, mismatch_description=None):
+        return self.element in item
+
+    def describe_to(self, description):
+        description.append_text("a sequence has the {0} element".format(self.element))
+
+    def describe_mismatch(self, item, mismatch_description):
+        mismatch_description.append_text("the element not in this sequence")
+
+
+def hasitem(element):
+    """Custom has_item matcher with a short description."""
+    return HasItem(element)
+
+

--- a/lib/test_helper/utils.py
+++ b/lib/test_helper/utils.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import random
+import inspect
+import importlib                                                                          
 
 from os import urandom
 
@@ -55,3 +57,15 @@ class Node(object):
 
     def __repr__(self):
         return "Node({0}, {1}, {2})".format(self.host, self.port, self.group)
+
+def _get_testcases_items(testcases_module_name):
+    testcases_module = importlib.import_module(testcases_module_name)
+    for func_name, func in inspect.getmembers(testcases_module, inspect.isfunction):
+        if inspect.getmodule(func) == testcases_module:
+            yield func_name, func
+
+def get_testcases(testcases_module_name):
+    return [testcase for _, testcase in _get_testcases_items(testcases_module_name)]
+
+def get_testcases_names(testcases_module_name):
+    return [testcase_name for testcase_name, _ in _get_testcases_items(testcases_module_name)]

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -5,7 +5,8 @@ def pytest_addoption(parser):
                      help="Amount of files to write which will be accessible from some groups.")
     parser.addoption('--file-size', type='int', default=0, dest="file_size",
                      help="Amount of bytes for a single file.")
-    parser.addoption('--broken-files-percentage', type=float, dest="broken_files_percentage",
+    parser.addoption('--inconsistent-files-percentage', type=float,
+                     dest="inconsistent_files_percentage",
                      help="Percentage of inconsistent keys which will not be recovered.")
     parser.addoption('--dropped-groups-path', dest="dropped_groups_path",
                      help="Path to a file with a list of elliptics groups where bad keys "

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -1,20 +1,16 @@
 def pytest_addoption(parser):
-    parser.addoption('--good-files-number', type='int', default='127', dest="good_files_number",
+    parser.addoption('--consistent-files-number', type='int', dest="consistent_files_number",
                      help="Amount of files to write which will be accessible from all groups.")
-    parser.addoption('--bad-files-number', type='int', default='256', dest="bad_files_number",
-                     help="Amount of files to write which will be accessible from some groups "
-                     "and will be recovered.")
-    parser.addoption('--broken-files-number', type='int', default='127', dest="broken_files_number",
-                     help="Amount of files to write which will be accessible from some groups "
-                     "and will not be recovered.")
+    parser.addoption('--inconsistent-files-number', type='int', dest="inconsistent_files_number",
+                     help="Amount of files to write which will be accessible from some groups.")
     parser.addoption('--file-size', type='int', default=0, dest="file_size",
                      help="Amount of bytes for a single file.")
-    parser.addoption('--good-keys-path', dest="good_keys_path",
-                     help="Path to a file with a list of good keys (in JSON format).")
-    parser.addoption('--bad-keys-path', dest="bad_keys_path",
-                     help="Path to a file with a list of bad keys (in JSON format).")
-    parser.addoption('--broken-keys-path', dest="broken_keys_path",
-                     help="Path to a file with a list of broken keys (in JSON format).")
-    parser.addoption('--dropped-groups', dest="dropped_groups",
+    parser.addoption('--broken-files-percentage', type=float, dest="broken_files_percentage",
+                     help="Percentage of inconsistent keys which will not be recovered.")
+    parser.addoption('--dropped-groups-path', dest="dropped_groups_path",
                      help="Path to a file with a list of elliptics groups where bad keys "
                      "will be recovered (in JSON format).")
+    parser.addoption('--consistent-keys-path', dest="consistent_keys_path",
+                     help="Path to a file with a list of consistent keys (in JSON format).")
+    parser.addoption('--inconsistent-keys-path', dest="inconsistent_keys_path",
+                     help="Path to a file with a list of inconsistent keys (in JSON format).")

--- a/tests/unstable/conftest.py
+++ b/tests/unstable/conftest.py
@@ -7,7 +7,7 @@ def pytest_addoption(parser):
     parser.addoption('--broken-files-number', type='int', default='127', dest="broken_files_number",
                      help="Amount of files to write which will be accessible from some groups "
                      "and will not be recovered.")
-    parser.addoption('--files-size', type='int', default=0, dest="files_size",
+    parser.addoption('--file-size', type='int', default=0, dest="file_size",
                      help="Amount of bytes for a single file.")
     parser.addoption('--good-keys-path', dest="good_keys_path",
                      help="Path to a file with a list of good keys (in JSON format).")

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -31,7 +31,7 @@ see `py.test --help`):
     --good-files-number=70 \
     --bad-files-number=100 \
     --broken-files-number=50 \
-    --files-size=102400 \
+    --file-size=102400 \
     tests/unstable/
 
 Example of running tests with prepared files with information about written data:
@@ -58,29 +58,25 @@ import elliptics
 import subprocess
 import random
 import json
+import os
 
-from hamcrest import assert_that, raises, calling, equal_to, described_as
+from hamcrest import assert_that, raises, calling, equal_to
 
-from test_helper.elliptics_testhelper import EllipticsTestHelper, nodes
-from test_helper.utils import get_sha1, get_key_and_data
+from test_helper.elliptics_testhelper import nodes
+from test_helper.utils import get_sha1
 from test_helper.logging_tests import logger
+from test_helper.matchers import hasitem
+
+import utils
+import testcases_recovery_dc
 
 
-def write_files(session, files_number, file_size):
-    """Writes files with preset session and specified files parameters: numbers and size."""
-    logger.info("Started writing {0} files\n".format(files_number))
-
-    key_list = []
-    for i in xrange(files_number):
-        key, data = get_key_and_data(file_size, randomize_len=False)
-
-        session.write_data(key, data).wait()
-        key_list.append(key)
-        logger.info("\r{0}/{1}".format(i + 1, files_number))
-
-    logger.info("\nFinished writing files\n")
-
-    return key_list
+@pytest.fixture(scope='module')
+def indexes():
+    """Returns randomly generated indexes."""
+    indexes_count = 5
+    index_length = 20
+    return [os.urandom(index_length) for _ in xrange(indexes_count)]
 
 
 @pytest.fixture(scope='module')
@@ -101,101 +97,128 @@ def dropped_groups(pytestconfig, session):
     return groups
 
 
-@pytest.fixture(scope='function')
-def good_keys(pytestconfig, session):
-    """Returns list of "good" keys."""
-    if pytestconfig.option.good_keys_path:
-        good_keys = json.load(open(pytestconfig.option.good_keys_path))
-        good_keys = [str(k) for k in good_keys]
-    else:
-        good_keys = write_files(session,
-                                pytestconfig.option.good_files_number,
-                                pytestconfig.option.files_size)
-    return good_keys
+recovery_dc_testcases = utils.get_testcases(testcases_recovery_dc)
 
 
-@pytest.fixture(scope='function')
-def bad_keys(pytestconfig, session, dropped_groups):
-    """Returns list of "bad" keys."""
-    if pytestconfig.option.bad_keys_path:
-        bad_keys = json.load(open(pytestconfig.option.bad_keys_path))
-        bad_keys = [str(k) for k in bad_keys]
-    else:
-        restricted_session = session.clone()
-        # "Bad" keys will be written in all groups except groups from dropped_groups
-        restricted_session.set_groups([g for g in restricted_session.groups if g not in dropped_groups])
-        bad_keys = write_files(restricted_session,
-                               pytestconfig.option.bad_files_number,
-                               pytestconfig.option.files_size)
+@pytest.fixture(scope='module',
+                params=recovery_dc_testcases,
+                ids=[case_func.__name__ for case_func in recovery_dc_testcases])
+def recovery(pytestconfig, request, session, nodes, indexes, dropped_groups):
+    """Returns an object with information about recovery operation."""
+    recovery = {
+        "cmd": None,
+        "exitcode": None,
+        "dropped_groups": dropped_groups,
+        "keys": {
+            "good": utils.get_good_keys(session,
+                                        pytestconfig.option.good_keys_path,
+                                        pytestconfig.option.good_files_number,
+                                        pytestconfig.option.file_size,
+                                        indexes),
+            "bad": utils.get_bad_keys(session,
+                                      pytestconfig.option.bad_keys_path,
+                                      pytestconfig.option.bad_files_number,
+                                      pytestconfig.option.file_size,
+                                      indexes,
+                                      dropped_groups),
+            "broken": utils.get_broken_keys(session,
+                                            pytestconfig.option.broken_keys_path,
+                                            pytestconfig.option.broken_files_number,
+                                            pytestconfig.option.file_size,
+                                            indexes,
+                                            dropped_groups)
+        }
+    }
 
-    return bad_keys
+    recovery = request.param(session, nodes, recovery)
+    logger.info("{}\n".format(recovery["cmd"]))
 
+    recovery["exitcode"] = subprocess.call(recovery["cmd"])
 
-@pytest.fixture(scope='function')
-def broken_keys(pytestconfig, session, dropped_groups):
-    """Returns list of "broken" keys."""
-    if pytestconfig.option.broken_keys_path:
-        broken_keys = json.load(open(pytestconfig.option.broken_keys_path))
-        broken_keys = [str(k) for k in broken_keys]
-    else:
-        restricted_session = session.clone()
-        # "Broken" keys will be written in all groups except groups from dropped_groups
-        restricted_session.set_groups([g for g in restricted_session.groups
-                                       if g not in dropped_groups])
-        broken_keys = write_files(restricted_session,
-                                  pytestconfig.option.broken_files_number,
-                                  pytestconfig.option.files_size)
-
-    return broken_keys
-
-
-@pytest.fixture(scope='function')
-def dump_file(session, bad_keys):
-    """Writes id of keys to a dump file and returns the file name."""
-    ids = [str(session.transform(k)) for k in bad_keys]
-    file_name = "id_dump"
-    with open(file_name, "w") as f:
-        f.write("\n".join(ids))
-    return file_name
+    return recovery
 
 
-def test_dump_file(session, nodes, good_keys, bad_keys, broken_keys, dropped_groups, dump_file):
-    """Testing `dnet_recovery` with `--dump-file` option."""
-    node = random.choice(nodes)
-    cmd = ["dnet_recovery",
-           "--remote", "{}:{}:2".format(node.host, node.port),
-           "--groups", ','.join([str(g) for g in session.groups]),
-           "--dump-file", dump_file,
-           "dc"]
-    logger.info("{}\n".format(cmd))
+def test_exit_code(recovery):
+    """Testing that `dnet_recovery` will be processed with exit status code = 0."""
+    assert_that(recovery["exitcode"], equal_to(0),
+                "`dnet_recovery` exited with non-zero exit code: {}\n"
+                "Running details: {}".format(recovery["exitcode"], recovery["cmd"]))
 
-    retcode = subprocess.call(cmd)
-    assert retcode == 0, "{} retcode = {}".format(cmd, retcode)
 
-    logger.info('Checking recovered keys...\n')
-    for k in bad_keys:
-        for g in session.groups:
-            result = session.read_data_from_groups(k, [g]).get()[0]
-            assert_that(k, equal_to(get_sha1(result.data)),
+def test_consistent_keys(session, recovery):
+    """Testing that after recovery operation keys, which were availabe in all groups,
+    are still available in all groups and have correct data."""
+    for key in recovery["keys"]["good"]:
+        for group in session.groups:
+            result = session.read_data_from_groups(key, [group]).get()[0]
+            assert_that(key, equal_to(get_sha1(result.data)),
+                        "After recovering the data mismatch by sha1 hash")
+
+
+def test_recovered_keys(session, recovery):
+    """Testing that after recovery operation keys, which had to be recovered,
+    are recovered and have correct data."""
+    for key in recovery["keys"]["bad"]:
+        for group in session.groups:
+            result = session.read_data_from_groups(key, [group]).get()[0]
+            assert_that(key, equal_to(get_sha1(result.data)),
                         "The recovered data mismatch by sha1 hash")
 
-    logger.info('Checking "good" keys...\n')
-    for k in good_keys:
-        for g in session.groups:
-            result = session.read_data_from_groups(k, [g]).get()[0]
-            assert_that(k, equal_to(get_sha1(result.data)),
+
+def test_inconsistent_keys(session, recovery):
+    """Testing that after recovery operation keys, which were available in some specific groups,
+    are still available in these groups and have correct data."""
+    available_groups = [group for group in session.groups
+                        if group not in recovery["dropped_groups"]]
+    for key in recovery["keys"]["broken"]:
+        for group in available_groups:
+            result = session.read_data_from_groups(key, [group]).get()[0]
+            assert_that(key, equal_to(get_sha1(result.data)),
                         "After recovering the data mismatch by sha1 hash")
 
-    logger.info('Check "broken" keys...\n')
-    available_groups = [g for g in session.groups if g not in dropped_groups]
-    for k in broken_keys:
-        for g in available_groups:
-            result = session.read_data_from_groups(k, [g]).get()[0]
-            assert_that(k, equal_to(get_sha1(result.data)),
-                        "After recovering the data mismatch by sha1 hash")
 
-    for k in broken_keys:
-        for g in dropped_groups:
-            async_result = session.read_data_from_groups(k, [g])
+def test_inconsistent_keys_wrong_access(session, recovery):
+    """Testing that after recovery operation keys, which were available in some specific groups,
+    are not available in other groups."""
+    for key in recovery["keys"]["broken"]:
+        for group in recovery["dropped_groups"]:
+            async_result = session.read_data_from_groups(key, [group])
             assert_that(calling(async_result.wait),
                         raises(elliptics.NotFoundError))
+
+
+def test_indexes_return_all_available_keys(session, recovery, indexes):
+    """Testing that after recovery operation searching by indexes, which were not available
+    in some groups before recovery operation, will return all keys for each index in each group."""
+    for index in indexes:
+        for group in session.groups:
+            restricted_session = session.clone()
+            restricted_session.set_groups([group])
+
+            result_keys = restricted_session.find_all_indexes([index]).get()
+            result_keys_ids = [key.id for key in result_keys]
+
+            expected_keys = utils.get_expected_keys(recovery, group, index)
+            for expected_key in expected_keys:
+                assert_that(result_keys_ids, hasitem(session.transform(expected_key)),
+                            'Expected key "{}" not found when was searching for index "{}" '
+                            'in group {}'.format(expected_key, index, group))
+
+
+def test_indexes_have_expected_data(session, recovery, indexes):
+    """Testing that after recovery operation key-index data will be correct for all keys,
+    which had to be recovered or were available before recovery operation."""
+    for index in indexes:
+        for group in session.groups:
+            restricted_session = session.clone()
+            restricted_session.set_groups([group])
+
+            expected_keys = utils.get_expected_keys(recovery, group, index)
+            for expected_key in expected_keys:
+                key_indexes = restricted_session.list_indexes(expected_key).get()
+                filtered_data = [index_entry.data for index_entry in key_indexes
+                                 if index_entry.index == restricted_session.transform(index)]
+                key_index_data = filtered_data[0]
+                assert_that(key_index_data, equal_to(utils.index_data_format(expected_key, index)),
+                            'Key-index (key = "{}", index = "{}") data mismatch in group {}'
+                            .format(expected_key, index, group))

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -91,7 +91,7 @@ def dropped_groups(pytestconfig, session):
                 params=get_testcases("testcases_recovery_dc"),
                 ids=get_testcases_names("testcases_recovery_dc"))
 def recovery(pytestconfig, request, session, nodes, indexes, dropped_groups):
-    """Returns a structure of recovery's data."""
+    """Returns a structure of recovery data."""
     recovery = request.param(pytestconfig.option, session, nodes, dropped_groups, indexes)
     logger.info("{}\n".format(recovery["cmd"]))
 

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -150,7 +150,7 @@ def test_inconsistent_keys_wrong_access(session, recovery, dropped_groups):
                         raises(elliptics.NotFoundError))
 
 
-def test_indexes_return_all_available_keys(session, recovery, indexes, dropped_groups):
+def test_indexes_searching(session, recovery, indexes, dropped_groups):
     """Testing that after recovery operation searching by indexes, which were not available
     in some groups before recovery operation, will return all keys for each index in each group."""
     for index in indexes:
@@ -168,7 +168,7 @@ def test_indexes_return_all_available_keys(session, recovery, indexes, dropped_g
                             'in group {}'.format(expected_key, index, group))
 
 
-def test_indexes_have_expected_data(session, recovery, indexes, dropped_groups):
+def test_key_index_data(session, recovery, indexes, dropped_groups):
     """Testing that after recovery operation key-index data will be correct for all keys,
     which had to be recovered or were available before recovery operation."""
     for index in indexes:

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -63,7 +63,7 @@ import os
 from hamcrest import assert_that, raises, calling, equal_to
 
 from test_helper.elliptics_testhelper import nodes
-from test_helper.utils import get_sha1
+from test_helper.utils import get_sha1, get_testcases, get_testcases_names
 from test_helper.logging_tests import logger
 from test_helper.matchers import hasitem
 
@@ -97,12 +97,9 @@ def dropped_groups(pytestconfig, session):
     return groups
 
 
-recovery_dc_testcases = utils.get_testcases(testcases_recovery_dc)
-
-
 @pytest.fixture(scope='module',
-                params=recovery_dc_testcases,
-                ids=[case_func.__name__ for case_func in recovery_dc_testcases])
+                params=get_testcases("testcases_recovery_dc"),
+                ids=get_testcases_names("testcases_recovery_dc"))
 def recovery(pytestconfig, request, session, nodes, indexes, dropped_groups):
     """Returns an object with information about recovery operation."""
     recovery = {

--- a/tests/unstable/test_recovery_dc.py
+++ b/tests/unstable/test_recovery_dc.py
@@ -64,7 +64,6 @@ from test_helper.logging_tests import logger
 from test_helper.matchers import hasitem
 
 import utils
-import testcases_recovery_dc
 
 
 @pytest.fixture(scope='module')

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -108,6 +108,7 @@ def recovery_with_one_node_option(options, session, nodes, dropped_groups, index
         else:
             node_inconsistent_keys[key] = key_indexes
 
+    result["keys"]["consistent"] = keys["consistent"]
     result["keys"]["recovered"] = node_recovered_keys
     result["keys"]["inconsistent"] = node_inconsistent_keys
 

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -29,18 +29,11 @@ def default_recovery(session, nodes, recovery):
     return result
 
 
-def _dump_keys_to_file(session, keys, file_path):
-    """Writes id of given keys to a dump file."""
-    ids = [str(session.transform(k)) for k in keys]
-    with open(file_path, "w") as dump_file:
-        dump_file.write("\n".join(ids))
-
-
 def recovery_with_dump_file_option(session, nodes, recovery):
     """Returns an object with specified information about recovery with `--dump-file` option."""
     result = copy.deepcopy(recovery)
     dump_file_path = "./dump_file"
-    _dump_keys_to_file(session, recovery["keys"]["bad"], dump_file_path)
+    utils.dump_keys_to_file(session, recovery["keys"]["bad"], dump_file_path)
     node = random.choice(nodes)
     result["cmd"] = ["dnet_recovery",
                      "--remote", "{}:{}:2".format(node.host, node.port),

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -51,6 +51,9 @@ def recovery_with_dump_file_option(options, session, nodes, dropped_groups, inde
     broken_keys_number = int(len(keys["inconsistent"]) * options.broken_files_percentage)
     broken_keys = dict(keys["inconsistent"].items()[:broken_keys_number])
     bad_keys = dict(keys["inconsistent"].items()[broken_keys_number:])
+    # Remove indexes from bad keys - they will not be recovered
+    for key in bad_keys:
+        bad_keys[key] = set()
 
     result["keys"]["good"] = keys["consistent"]
     result["keys"]["bad"] = bad_keys
@@ -104,7 +107,8 @@ def recovery_with_one_node_option(options, session, nodes, dropped_groups, index
     for key, key_indexes in keys["inconsistent"].items():
         key_id = session.transform(key)
         if key_id in ranges[host]:
-            node_bad_keys[key] = key_indexes
+            # Remove indexes from bad keys - they will not be recovered
+            node_bad_keys[key] = set()
         else:
             node_broken_keys[key] = key_indexes
 

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -53,7 +53,7 @@ def recovery_with_dump_file_option(options, session, nodes, dropped_groups, inde
     result = copy.deepcopy(recovery_skeleton)
 
     keys = utils.get_keys(options, session, dropped_groups, indexes)
-    # Split inconsistent keys to "bad" and "broken" keys
+    # Split inconsistent keys: keys which will be recovered and keys which will not be
     inconsistent_keys_number = int(len(keys["inconsistent"]) * options.inconsistent_files_percentage)
     inconsistent_keys = dict(keys["inconsistent"].items()[:inconsistent_keys_number])
     recovered_keys = dict(keys["inconsistent"].items()[inconsistent_keys_number:])

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -9,6 +9,7 @@ For more information about this structure see `recovery_skeleton` below.
 
 import random
 import copy
+import socket
 
 import utils
 
@@ -94,13 +95,14 @@ def recovery_with_one_node_option(options, session, nodes, dropped_groups, index
     keys = utils.get_keys(options, session, dropped_groups, indexes)
     # Split inconsistent keys to recovered and still inconsistent keys
     # depend on following condition: "is the key belong to chosen node?"
-    ranges = utils.get_ranges_by_session(session, nodes)
-    host = repr(node)
+    node_address = socket.gethostbyname(node.host)
     node_recovered_keys = {}
     node_inconsistent_keys = {}
     for key, key_indexes in keys["inconsistent"].items():
         key_id = session.transform(key)
-        if key_id in ranges[host]:
+        key_node = session.lookup_address(key_id, node.group)
+        if node_address == key_node.host and \
+           node.port == key_node.port:
             # Remove indexes from bad keys - they will not be recovered
             node_recovered_keys[key] = set()
         else:

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -72,19 +72,10 @@ def recovery_with_dump_file_option(options, session, nodes, dropped_groups, inde
 
 def recovery_with_nprocess_option(options, session, nodes, dropped_groups, indexes):
     """Test case for recovery with `--nprocess` option."""
-    result = copy.deepcopy(recovery_skeleton)
+    result = default_recovery(options, session, nodes, dropped_groups, indexes)
 
-    keys = utils.get_keys(options, session, dropped_groups, indexes)
-
-    result["keys"]["good"] = keys["consistent"]
-    result["keys"]["bad"] = keys["inconsistent"]
-
-    node = random.choice(nodes)
-    result["cmd"] = ["dnet_recovery",
-                     "--remote", "{}:{}:2".format(node.host, node.port),
-                     "--groups", ','.join([str(g) for g in session.groups]),
-                     "--nprocess", "3",
-                     "dc"]
+    # adding --nprocess option to default recovery command
+    result["cmd"].extend(["--nprocess", "3"])
 
     return result
 

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -1,0 +1,91 @@
+"""Test cases for elliptics recovery dc tests.
+
+Public functions from this module will be used for parameterizing fixture
+for elliptics recovery dc tests.
+
+They have a parameter **recovery** to get a skeleton object with information
+about writen keys to elliptics cluster. These functions return object with
+specified information about recovery with specific options. For more information
+about **recovery** object see `recovery` fixture from `test_recovery_dc.py`.
+
+"""
+
+import random
+import copy
+
+import utils
+
+
+def default_recovery(session, nodes, recovery):
+    """Returns an object with specified information about recovery with no special options."""
+    result = copy.deepcopy(recovery)
+    node = random.choice(nodes)
+    result["cmd"] = ["dnet_recovery",
+                     "--remote", "{}:{}:2".format(node.host, node.port),
+                     "--groups", ','.join([str(g) for g in session.groups]),
+                     "dc"]
+    result["keys"]["bad"].update(result["keys"]["broken"])
+    result["keys"]["broken"].clear()
+    return result
+
+
+def _dump_keys_to_file(session, keys, file_path):
+    """Writes id of given keys to a dump file."""
+    ids = [str(session.transform(k)) for k in keys]
+    with open(file_path, "w") as dump_file:
+        dump_file.write("\n".join(ids))
+
+
+def recovery_with_dump_file_option(session, nodes, recovery):
+    """Returns a command to run `dnet_recovery` with `--dump-file` option."""
+    result = copy.deepcopy(recovery)
+    dump_file_path = "./dump_file"
+    _dump_keys_to_file(session, recovery["keys"]["bad"], dump_file_path)
+    node = random.choice(nodes)
+    result["cmd"] = ["dnet_recovery",
+                     "--remote", "{}:{}:2".format(node.host, node.port),
+                     "--groups", ','.join([str(g) for g in session.groups]),
+                     "--dump-file", dump_file_path,
+                     "dc"]
+    return result
+
+
+def recovery_with_nprocess_option(session, nodes, recovery):
+    """Returns a command to run `dnet_recovery` with `--nprocess` option."""
+    result = copy.deepcopy(recovery)
+    node = random.choice(nodes)
+    result["cmd"] = ["dnet_recovery",
+                     "--remote", "{}:{}:2".format(node.host, node.port),
+                     "--groups", ','.join([str(g) for g in session.groups]),
+                     "--nprocess", "3",
+                     "dc"]
+    result["keys"]["bad"].update(result["keys"]["broken"])
+    result["keys"]["broken"].clear()
+    return result
+
+
+def recovery_with_one_node_option(session, nodes, recovery):
+    """Returns a command to run `dnet_recovery` with `--one-node` option."""
+    result = copy.deepcopy(recovery)
+    available_nodes = [node for node in nodes
+                       if node.group not in recovery["dropped_groups"]]
+    node = random.choice(available_nodes)
+    result["cmd"] = ["dnet_recovery",
+                     "--one-node", "{}:{}:2".format(node.host, node.port),
+                     "--groups", ','.join([str(g) for g in session.groups]),
+                     "dc"]
+    # Redistribute keys depend on chosen node
+    ranges = utils.get_ranges_by_session(session, nodes)
+    node_bad_keys = {}
+    node_broken_keys = {}
+    for key_type in ["bad", "broken"]:
+        for key in result["keys"][key_type]:
+            key_id = session.transform(key)
+            host = repr(node)
+            if key_id in ranges[host]:
+                node_bad_keys[key] = result["keys"][key_type][key]
+            else:
+                node_broken_keys[key] = result["keys"][key_type][key]
+    result["keys"]["bad"] = node_bad_keys
+    result["keys"]["broken"] = node_broken_keys
+    return result

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -1,12 +1,9 @@
 """Test cases for elliptics recovery dc tests.
 
-Public functions from this module will be used for parameterizing fixture
-for elliptics recovery dc tests.
-
-They have a parameter **recovery** to get a skeleton object with information
-about writen keys to elliptics cluster. These functions return object with
-specified information about recovery with specific options. For more information
-about **recovery** object see `recovery` fixture from `test_recovery_dc.py`.
+Functions from this module will be used to parameterize fixture
+for elliptics recovery dc tests. These functions return a structure
+of recovery's data. For more information about this structure see
+`recovery_skeleton` below.
 
 """
 
@@ -16,24 +13,51 @@ import copy
 import utils
 
 
-def default_recovery(session, nodes, recovery):
-    """Returns an object with specified information about recovery with no special options."""
-    result = copy.deepcopy(recovery)
+recovery_skeleton = {
+    "cmd": None,
+    "exitcode": None,
+    "keys": {
+        "good": {},
+        "bad": {},
+        "broken": {}
+    }
+}
+
+
+def default_recovery(options, session, nodes, dropped_groups, indexes):
+    """Test case for recovery with no special options."""
+    result = copy.deepcopy(recovery_skeleton)
+
+    keys = utils.get_keys(options, session, dropped_groups, indexes)
+
+    result["keys"]["good"] = keys["consistent"]
+    result["keys"]["bad"] = keys["inconsistent"]
+
     node = random.choice(nodes)
     result["cmd"] = ["dnet_recovery",
                      "--remote", "{}:{}:2".format(node.host, node.port),
                      "--groups", ','.join([str(g) for g in session.groups]),
                      "dc"]
-    result["keys"]["bad"].update(result["keys"]["broken"])
-    result["keys"]["broken"].clear()
+
     return result
 
 
-def recovery_with_dump_file_option(session, nodes, recovery):
-    """Returns an object with specified information about recovery with `--dump-file` option."""
-    result = copy.deepcopy(recovery)
+def recovery_with_dump_file_option(options, session, nodes, dropped_groups, indexes):
+    """Test case for recovery with `--dump-file` option."""
+    result = copy.deepcopy(recovery_skeleton)
+
+    keys = utils.get_keys(options, session, dropped_groups, indexes)
+    # Split inconsistent keys to "bad" and "broken" keys
+    broken_keys_number = int(len(keys["inconsistent"]) * options.broken_files_percentage)
+    broken_keys = dict(keys["inconsistent"].items()[:broken_keys_number])
+    bad_keys = dict(keys["inconsistent"].items()[broken_keys_number:])
+
+    result["keys"]["good"] = keys["consistent"]
+    result["keys"]["bad"] = bad_keys
+    result["keys"]["broken"] = broken_keys
+
     dump_file_path = "./dump_file"
-    utils.dump_keys_to_file(session, recovery["keys"]["bad"], dump_file_path)
+    utils.dump_keys_to_file(session, result["keys"]["bad"], dump_file_path)
     node = random.choice(nodes)
     result["cmd"] = ["dnet_recovery",
                      "--remote", "{}:{}:2".format(node.host, node.port),
@@ -43,42 +67,53 @@ def recovery_with_dump_file_option(session, nodes, recovery):
     return result
 
 
-def recovery_with_nprocess_option(session, nodes, recovery):
-    """Returns an object with specified information about recovery with `--nprocess` option."""
-    result = copy.deepcopy(recovery)
+def recovery_with_nprocess_option(options, session, nodes, dropped_groups, indexes):
+    """Test case for recovery with `--nprocess` option."""
+    result = copy.deepcopy(recovery_skeleton)
+
+    keys = utils.get_keys(options, session, dropped_groups, indexes)
+
+    result["keys"]["good"] = keys["consistent"]
+    result["keys"]["bad"] = keys["inconsistent"]
+
     node = random.choice(nodes)
     result["cmd"] = ["dnet_recovery",
                      "--remote", "{}:{}:2".format(node.host, node.port),
                      "--groups", ','.join([str(g) for g in session.groups]),
                      "--nprocess", "3",
                      "dc"]
-    result["keys"]["bad"].update(result["keys"]["broken"])
-    result["keys"]["broken"].clear()
+
     return result
 
 
-def recovery_with_one_node_option(session, nodes, recovery):
-    """Returns an object with specified information about recovery with `--one-node` option."""
-    result = copy.deepcopy(recovery)
+def recovery_with_one_node_option(options, session, nodes, dropped_groups, indexes):
+    """Test case for recovery with `--one-node` option."""
+    result = copy.deepcopy(recovery_skeleton)
+
     available_nodes = [node for node in nodes
-                       if node.group not in recovery["dropped_groups"]]
+                       if node.group not in dropped_groups]
     node = random.choice(available_nodes)
+
+    keys = utils.get_keys(options, session, dropped_groups, indexes)
+    # Split inconsistent keys to "bad" and "broken" keys
+    # depend on following condition: "is the key belong to chosen node?"
+    ranges = utils.get_ranges_by_session(session, nodes)
+    host = repr(node)
+    node_bad_keys = {}
+    node_broken_keys = {}
+    for key, key_indexes in keys["inconsistent"].items():
+        key_id = session.transform(key)
+        if key_id in ranges[host]:
+            node_bad_keys[key] = key_indexes
+        else:
+            node_broken_keys[key] = key_indexes
+
+    result["keys"]["bad"] = node_bad_keys
+    result["keys"]["broken"] = node_broken_keys
+
     result["cmd"] = ["dnet_recovery",
                      "--one-node", "{}:{}:2".format(node.host, node.port),
                      "--groups", ','.join([str(g) for g in session.groups]),
                      "dc"]
-    # Redistribute keys depend on chosen node
-    ranges = utils.get_ranges_by_session(session, nodes)
-    node_bad_keys = {}
-    node_broken_keys = {}
-    for key_type in ["bad", "broken"]:
-        for key in result["keys"][key_type]:
-            key_id = session.transform(key)
-            host = repr(node)
-            if key_id in ranges[host]:
-                node_bad_keys[key] = result["keys"][key_type][key]
-            else:
-                node_broken_keys[key] = result["keys"][key_type][key]
-    result["keys"]["bad"] = node_bad_keys
-    result["keys"]["broken"] = node_broken_keys
+
     return result

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -37,7 +37,7 @@ def _dump_keys_to_file(session, keys, file_path):
 
 
 def recovery_with_dump_file_option(session, nodes, recovery):
-    """Returns a command to run `dnet_recovery` with `--dump-file` option."""
+    """Returns an object with specified information about recovery with `--dump-file` option."""
     result = copy.deepcopy(recovery)
     dump_file_path = "./dump_file"
     _dump_keys_to_file(session, recovery["keys"]["bad"], dump_file_path)
@@ -51,7 +51,7 @@ def recovery_with_dump_file_option(session, nodes, recovery):
 
 
 def recovery_with_nprocess_option(session, nodes, recovery):
-    """Returns a command to run `dnet_recovery` with `--nprocess` option."""
+    """Returns an object with specified information about recovery with `--nprocess` option."""
     result = copy.deepcopy(recovery)
     node = random.choice(nodes)
     result["cmd"] = ["dnet_recovery",
@@ -65,7 +65,7 @@ def recovery_with_nprocess_option(session, nodes, recovery):
 
 
 def recovery_with_one_node_option(session, nodes, recovery):
-    """Returns a command to run `dnet_recovery` with `--one-node` option."""
+    """Returns an object with specified information about recovery with `--one-node` option."""
     result = copy.deepcopy(recovery)
     available_nodes = [node for node in nodes
                        if node.group not in recovery["dropped_groups"]]

--- a/tests/unstable/testcases_recovery_dc.py
+++ b/tests/unstable/testcases_recovery_dc.py
@@ -2,8 +2,8 @@
 
 Functions from this module will be used to parameterize fixture for
 elliptics recovery dc tests. These functions return a structure of
-recovery's data (with these data we will check recovery operation).
-For more information about this structure see `recovery_skeleton` below.
+recovery data (with these data we will check recovery operation). For
+more information about this structure see `recovery_skeleton` below.
 
 """
 

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -107,7 +107,7 @@ def get_expected_keys(recovery, group, index, dropped_groups):
     expected_keys = [key for key, key_indexes in recovery["keys"]["consistent"].items()
                      if index in key_indexes]
     expected_keys.extend([key for key, key_indexes in recovery["keys"]["recovered"].items()
-                          if index in key_indexes])
+                          if index in key_indexes and recovery["recovery_indexes"]])
     if group not in dropped_groups:
         expected_keys.extend([key for key, key_indexes in recovery["keys"]["inconsistent"].items()
                               if index in key_indexes])

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -104,8 +104,11 @@ def get_expected_keys(recovery, group, index, dropped_groups):
     """Returns a list of all keys for the index that should be available in the group."""
     expected_keys = [key for key, key_indexes in recovery["keys"]["consistent"].items()
                      if index in key_indexes]
+    # add recovered keys if their indexes were recovered or we are checking indexes in group
+    # which was available and had indexes before recovery operation
     expected_keys.extend([key for key, key_indexes in recovery["keys"]["recovered"].items()
-                          if index in key_indexes and recovery["recovery_indexes"]])
+                          if index in key_indexes and
+                          (recovery["recovery_indexes"] or group not in dropped_groups)])
     if group not in dropped_groups:
         expected_keys.extend([key for key, key_indexes in recovery["keys"]["inconsistent"].items()
                               if index in key_indexes])

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -1,7 +1,5 @@
-import inspect
 import random
 import json
-import socket
 
 from test_helper.logging_tests import logger
 from test_helper.utils import get_key_and_data

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -104,12 +104,12 @@ def get_keys(options, session, dropped_groups, indexes):
 
 def get_expected_keys(recovery, group, index, dropped_groups):
     """Returns a list of all keys for the index that should be available in the group."""
-    expected_keys = [key for key, key_indexes in recovery["keys"]["good"].items()
+    expected_keys = [key for key, key_indexes in recovery["keys"]["consistent"].items()
                      if index in key_indexes]
-    expected_keys.extend([key for key, key_indexes in recovery["keys"]["bad"].items()
+    expected_keys.extend([key for key, key_indexes in recovery["keys"]["recovered"].items()
                           if index in key_indexes])
     if group not in dropped_groups:
-        expected_keys.extend([key for key, key_indexes in recovery["keys"]["broken"].items()
+        expected_keys.extend([key for key, key_indexes in recovery["keys"]["inconsistent"].items()
                               if index in key_indexes])
     return expected_keys
 

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -106,9 +106,9 @@ def get_expected_keys(recovery, group, index, dropped_groups):
                      if index in key_indexes]
     # add recovered keys if their indexes were recovered or we are checking indexes in group
     # which was available and had indexes before recovery operation
-    expected_keys.extend([key for key, key_indexes in recovery["keys"]["recovered"].items()
-                          if index in key_indexes and
-                          (recovery["recovery_indexes"] or group not in dropped_groups)])
+    if recovery["recovery_indexes"] or group not in dropped_groups:
+        expected_keys.extend([key for key, key_indexes in recovery["keys"]["recovered"].items()
+                              if index in key_indexes])
     if group not in dropped_groups:
         expected_keys.extend([key for key, key_indexes in recovery["keys"]["inconsistent"].items()
                               if index in key_indexes])

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -7,17 +7,6 @@ from test_helper.logging_tests import logger
 from test_helper.utils import get_key_and_data
 
 
-def get_testcases(module):
-    """Returns testcases from given module (public functions from the module)."""
-    testcases = []
-    for func in module.__dict__.itervalues():
-        if inspect.isfunction(func) and \
-           inspect.getmodule(func) == module and \
-           not func.__name__.startswith("_"):
-            testcases.append(func)
-    return testcases
-
-
 def _write_files(session, files_number, file_size):
     """Writes files with preset session and specified files parameters: numbers and size."""
     logger.info("Started writing {} files\n".format(files_number))
@@ -189,3 +178,10 @@ def get_ranges_by_session(session, nodes):
                              node.port == address.port]
         ranges[filtered_hostname[0]] = Ranges(session.routes.get_address_ranges(address))
     return ranges
+
+
+def dump_keys_to_file(session, keys, file_path):
+    """Writes id of given keys to a dump file."""
+    ids = [str(session.transform(k)) for k in keys]
+    with open(file_path, "w") as dump_file:
+        dump_file.write("\n".join(ids))

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -114,45 +114,6 @@ def get_expected_keys(recovery, group, index, dropped_groups):
     return expected_keys
 
 
-class Range(object):
-    """Range of elliptics id."""
-    def __init__(self, couple):
-        self.left = couple[0]
-        self.right = couple[1]
-
-    def __contains__(self, item):
-        return self.left <= item < self.right
-
-
-class Ranges(object):
-    """Ranges for the following check: *is these ranges contains specified elliptics.Id*."""
-    def __init__(self, ranges_list):
-        self.ranges = []
-        for couple in ranges_list:
-            self.ranges.append(Range(couple))
-
-    def __contains__(self, item):
-        return any(item in r for r in self.ranges)
-
-
-def get_ranges_by_session(session, nodes):
-    """Returns ranges of elliptics id as dictionary:
-
-    {
-      repr(server-1): <ranges of elliptics id for server-1>,
-      ...
-    }
-
-    """
-    ranges = {}
-    for address in session.routes.addresses():
-        filtered_hostname = [repr(node) for node in nodes
-                             if socket.gethostbyname(node.host) == address.host and
-                             node.port == address.port]
-        ranges[filtered_hostname[0]] = Ranges(session.routes.get_address_ranges(address))
-    return ranges
-
-
 def dump_keys_to_file(session, keys, file_path):
     """Writes id of given keys to a dump file."""
     ids = [str(session.transform(k)) for k in keys]

--- a/tests/unstable/utils.py
+++ b/tests/unstable/utils.py
@@ -1,0 +1,191 @@
+import inspect
+import random
+import json
+import socket
+
+from test_helper.logging_tests import logger
+from test_helper.utils import get_key_and_data
+
+
+def get_testcases(module):
+    """Returns testcases from given module (public functions from the module)."""
+    testcases = []
+    for func in module.__dict__.itervalues():
+        if inspect.isfunction(func) and \
+           inspect.getmodule(func) == module and \
+           not func.__name__.startswith("_"):
+            testcases.append(func)
+    return testcases
+
+
+def _write_files(session, files_number, file_size):
+    """Writes files with preset session and specified files parameters: numbers and size."""
+    logger.info("Started writing {} files\n".format(files_number))
+
+    keys = set()
+    for i in xrange(files_number):
+        key, data = get_key_and_data(file_size, randomize_len=False)
+
+        session.write_data(key, data).wait()
+        keys.add(key)
+        logger.info("\r{}/{}".format(i + 1, files_number))
+
+    logger.info("\nFinished writing files\n")
+
+    return keys
+
+
+def index_data_format(key, index):
+    """Returns index data for given key and index."""
+    return "{}_{}".format(key, index)
+
+
+def _set_indexes(session, keys, indexes):
+    """Prepares secondary indexes.
+
+    Sets randomly chosen indexes for a given list of keys and
+    returns a dictionary with information about these indexes.
+
+    """
+    logger.info("Started setting indexes for {} keys...\n".format(len(keys)))
+
+    keys_indexes = {}
+    for i, key in enumerate(keys):
+        indexes_count = random.randint(0, len(indexes))
+        key_indexes = random.sample(indexes, indexes_count)
+        index_data = [index_data_format(key, index) for index in key_indexes]
+
+        session.set_indexes(key, key_indexes, index_data).wait()
+        keys_indexes[key] = set(key_indexes)
+
+        logger.info("\r{}/{}".format(i + 1, len(keys)))
+
+    logger.info("\nFinished setting indexes\n")
+
+    return keys_indexes
+
+
+def _load_keys_from_file(path):
+    """Returns keys from specified file."""
+    keys = json.load(open(path))
+    keys = {str(k) for k in keys}
+    return keys
+
+
+def _write_files_with_indexes(session, files_number, file_size, indexes):
+    """Writes files then sets indexes for these files."""
+    keys = _write_files(session, files_number, file_size)
+    keys = _set_indexes(session, keys, indexes)
+    return keys
+
+
+def get_good_keys(session, good_keys_path, good_files_number, file_size, indexes):
+    """Returns "good" keys.
+
+    If file with good keys was specified then it will return keys from the file.
+    Otherwise it will write keys and return these keys.
+
+    """
+    if good_keys_path:
+        good_keys = _load_keys_from_file(good_keys_path)
+    else:
+        good_keys = _write_files_with_indexes(session,
+                                              good_files_number,
+                                              file_size,
+                                              indexes)
+    return good_keys
+
+
+def get_bad_keys(session, bad_keys_path, bad_files_number,
+                 file_size, indexes, dropped_groups):
+    """Returns "bad" keys.
+
+    If file with bad keys was specified then it will return keys from the file.
+    Otherwise it will write keys and return these keys.
+
+    """
+    if bad_keys_path:
+        bad_keys = _load_keys_from_file(bad_keys_path)
+    else:
+        restricted_session = session.clone()
+        # "Bad" keys will be written in all groups except groups from dropped_groups
+        restricted_session.set_groups([g for g in restricted_session.groups
+                                       if g not in dropped_groups])
+        bad_keys = _write_files_with_indexes(restricted_session,
+                                             bad_files_number,
+                                             file_size,
+                                             indexes)
+    return bad_keys
+
+
+def get_broken_keys(session, broken_keys_path, broken_files_number,
+                    file_size, indexes, dropped_groups):
+    """Returns "broken" keys.
+
+    If file with broken keys was specified then it will return keys from the file.
+    Otherwise it will write keys and return these keys.
+
+    """
+    if broken_keys_path:
+        broken_keys = _load_keys_from_file(broken_keys_path)
+    else:
+        restricted_session = session.clone()
+        # "Broken" keys will be written in all groups except groups from dropped_groups
+        restricted_session.set_groups([g for g in restricted_session.groups
+                                       if g not in dropped_groups])
+        broken_keys = _write_files_with_indexes(restricted_session,
+                                                broken_files_number,
+                                                file_size,
+                                                indexes)
+    return broken_keys
+
+
+def get_expected_keys(recovery, group, index):
+    """Returns a list of all keys for the index that should be available in the group."""
+    expected_keys = [key for key, key_indexes in recovery["keys"]["good"].items()
+                     if index in key_indexes]
+    expected_keys.extend([key for key, key_indexes in recovery["keys"]["bad"].items()
+                          if index in key_indexes])
+    if group not in recovery["dropped_groups"]:
+        expected_keys.extend([key for key, key_indexes in recovery["keys"]["broken"].items()
+                              if index in key_indexes])
+    return expected_keys
+
+
+class Range(object):
+    """Range of elliptics id."""
+    def __init__(self, couple):
+        self.left = couple[0]
+        self.right = couple[1]
+
+    def __contains__(self, item):
+        return self.left <= item < self.right
+
+
+class Ranges(object):
+    """Ranges for the following check: *is these ranges contains specified elliptics.Id*."""
+    def __init__(self, ranges_list):
+        self.ranges = []
+        for couple in ranges_list:
+            self.ranges.append(Range(couple))
+
+    def __contains__(self, item):
+        return any(item in r for r in self.ranges)
+
+
+def get_ranges_by_session(session, nodes):
+    """Returns ranges of elliptics id as dictionary:
+
+    {
+      repr(server-1): <ranges of elliptics id for server-1>,
+      ...
+    }
+
+    """
+    ranges = {}
+    for address in session.routes.addresses():
+        filtered_hostname = [repr(node) for node in nodes
+                             if socket.gethostbyname(node.host) == address.host and
+                             node.port == address.port]
+        ranges[filtered_hostname[0]] = Ranges(session.routes.get_address_ranges(address))
+    return ranges


### PR DESCRIPTION
Это версия тестов восстановления, в которой включены изменения предложенные @uvizhe.

Здесь представлены тесты `dnet_recovery` с опциями `--dump-file`, `--one-node`, `--nprocess` и тесты для восстановления без специфичных опций. Кейсы тесов можно посмотреть в **testcases_recovery_dc.py**. Эти кейсы покрывают те кейсы, которые сейчас прогоняются при тестировании собранных пакетов (плюс есть тесты на `--dump-file`).

После слияния этих изменений, сделаю конфиги для запускатора под эти тесты и исключу старые тесты восстановления dc, а эти тесты будут гоняться и при тестировании собранных пакетов, и будут использоваться для тестов на большом объеме данных.

reviewers: @uvizhe, @tIGO, @shaitan
