### PR TITLE
fix: cache lru test - more requests to increase test verdict accuracy

### DIFF
--- a/configs/system-tests/test_cache-lru.cfg
+++ b/configs/system-tests/test_cache-lru.cfg
@@ -5,7 +5,7 @@
 	"cache_pages_proportions": [1, 1],
 	"cache_sync_timeout": 3600
         },
-    "addopts": "-k cache_lru --requests-number=10000 {% for node in servers %} --node={{ node.host }}:{{ node.port }}:{{ node.group }}{% endfor %}",
+    "addopts": "-k cache_lru --requests-number=200000 {% for node in servers %} --node={{ node.host }}:{{ node.port }}:{{ node.group }}{% endfor %}",
     "dir": "system-tests/cache-tests/lru-tests",
     "test_env_cfg": {
         "clients": {


### PR DESCRIPTION
Увеличил количество запросов в 20 раз. Раньше все запросы выполнялись за 3 секунды в среднем, теперь - за примерно 70 секунд. Вердикт тест выносит на основе оценки времени - второй прогон запросов должен выполниться не более чем за 70 \* 0.2 секунд (после того, как мы заполнили половину кэша мусором) - это будет 14 секунд, раньше было 0.6 секунд (в среднем).

reviewers: @uvizhe
