### PR TITLE
fix: for **setuptools must be installed to install from a source distribution** pip error

### DIFF
--- a/ansible/test-env-prepare.yml
+++ b/ansible/test-env-prepare.yml
@@ -16,6 +16,7 @@
       retries: 3
       delay: 10
       with_items:
+        - setuptools
         - pytest
         - pytest-xdist
         - pytest-timeout


### PR DESCRIPTION
Нужно устанавливать отдельно, так как в зависимостях пакета **python-pip** нет **python-setuptools** :/

reviewers: @uvizhe
