### PR TITLE
fix: for wrong exit status code when setup/teardown raising an exception

### DIFF
--- a/lib/ansible_manager.py
+++ b/lib/ansible_manager.py
@@ -7,6 +7,9 @@ import ConfigParser
 import openstack
 import teamcity_messages
 
+class AnsiblePlaybookError(Exception):
+    pass
+
 def get_vars(vars_path):
     if not os.path.isfile(vars_path):
         return {}
@@ -35,7 +38,8 @@ def run_playbook(playbook, inventory=None):
 
         p.wait()
         if p.returncode:
-            raise RuntimeError("Playbook {0} failed (exit code: {1})".format(playbook, p.returncode))
+            raise AnsiblePlaybookError("Playbook {} failed (exit code: {})".format(playbook,
+                                                                                   p.returncode))
 
 def generate_inventory_file(inventory_path, clients_count, servers_per_group,
                             groups, instances_names, os_hostname_prefix):


### PR DESCRIPTION
Пофиксил неправильное поведение запускатора: если setup/teardown теста бросают исключение, то это считается за ошибку теста, а не запускатора.

Так же добавил более понятное исключение для `ansible_manager`'а.

reviewers: @uvizhe
