### PR TITLE
fix: wiping out data before recovery tests

### DIFF
--- a/ansible/tests/setup-recovery-test.yml
+++ b/ansible/tests/setup-recovery-test.yml
@@ -1,0 +1,21 @@
+---
+- hosts: servers
+  tasks:
+    - name: Wipe out Elliptics data
+      file: path={{ item }} state=absent
+      with_items:
+        - "{{ log_dir }}"
+        - "{{ data_dir }}"
+        - "{{ hist_dir }}"
+
+    - name: Recreate necessary directories
+      file: path={{ item }} state=directory
+      with_items:
+        - "{{ log_dir }}"
+        - "{{ data_dir }}"
+        - "{{ hist_dir }}"
+
+    - name: Create data file
+      file: path={{ data_dir }}/data state=touch
+
+- include: ../elliptics-start.yml

--- a/configs/system-tests/test_dc.cfg
+++ b/configs/system-tests/test_dc.cfg
@@ -14,7 +14,7 @@
             "count_per_group": [2, 2, 2],
             "flavor": "m1.small"
             },
-	"setup_playbook": "elliptics-start",
+	"setup_playbook": "tests/setup-recovery-test",
 	"teardown_playbook": "elliptics-stop"
         },
     "tags": ["recovery-test", "system", "recovery-dc", "testing-packages"]

--- a/configs/system-tests/test_merge.cfg
+++ b/configs/system-tests/test_merge.cfg
@@ -13,7 +13,7 @@
             "count_per_group": [4],
             "flavor": "m1.small"
             },
-	"setup_playbook": "elliptics-start",
+	"setup_playbook": "tests/setup-recovery-test",
 	"teardown_playbook": "elliptics-stop"
         },
     "tags": ["recovery-test", "system", "recovery-merge", "testing-packages"]


### PR DESCRIPTION
Теперь удаляем данные перед тестами восстановления, чтобы оценивать сколько восстановление может занять времени.

@uvizhe
