### PR TITLE
test_mix_states was corrected and some small changes

### DIFF
--- a/lib/test_helper/network.py
+++ b/lib/test_helper/network.py
@@ -24,4 +24,4 @@ def del_scheduler(host):
     """Removes a scheduler for a network interface on specified host."""
     cmd = "ssh -q {} tc qdisc del dev eth0 root netem delay 0ms".format(host)
     subprocess.check_call(shlex.split(cmd))
-    logger.info("A sceduler for network emulator was removed for host: {}\n".format(host))
+    logger.info("A scheduler for network emulator was removed for host: {}\n".format(host))

--- a/tests/elliptics/mix-states/mix_states_utils.py
+++ b/tests/elliptics/mix-states/mix_states_utils.py
@@ -96,16 +96,16 @@ def do_requests(session, key, requests_number, trans_checker_params):
     return requests_count
 
 
-def stabilizing_requests(session, key, requests_count, retry_max, trans_checker_params):
+def do_requests_with_retry(session, key, requests_count, retry_max, trans_checker_params):
     """Does specified amount of requests to stabilize weights."""
     retry_number = 0
     while retry_number < retry_max:
         try:
-            do_requests(session, key, requests_count, trans_checker_params)
+            sample = do_requests(session, key, requests_count, trans_checker_params)
         except OvertimeError as exc:
-            logger.info("Failed to stabilize weights - retrying: {}\n".format(exc.message))
+            logger.info("Failed to do {} requests - retrying: {}\n".format(requests_count,
+                                                                           exc.message))
             retry_number += 1
         else:
-            return
-    raise RuntimeError("Retries count ({}) exceeded while was trying to stabilize weights."
-                       .format(retry_number))
+            return sample
+    return None

--- a/tests/elliptics/mix-states/mix_states_utils.py
+++ b/tests/elliptics/mix-states/mix_states_utils.py
@@ -1,0 +1,114 @@
+import time
+import json
+
+from collections import namedtuple
+
+from test_helper.logging_tests import logger
+
+
+class OvertimeError(Exception):
+    """Raised when Elliptics transaction took more time than upper bound for an
+    expected time.
+    """
+    pass
+
+
+def _follow(logfile):
+    """Follows a log-file in real-time like `tail -f` in Unix."""
+    logfile.seek(0, 2)
+    while True:
+        line = logfile.readline()
+        if not line:
+            time.sleep(0.1)
+            continue
+        yield line
+
+
+def _filter_destructions(loglines):
+    """Filters destruction records."""
+    for line in loglines:
+        info_start = line.find("destruction READ trans: ")
+        if info_start != -1:
+            # Parsing logged destruction record for READ operation
+            destruction_record = [tuple(field_value.strip().split(": "))
+                                  for field_value in line[info_start:].split(", ")]
+            destruction_record = dict(destruction_record)
+            yield destruction_record
+
+
+def get_logged_destructions(session, log_file):
+    """Returns iterable with logged destruction records."""
+    loglines = _follow(open(log_file))
+    # Write some data to create some new records in log file
+    session.write_data("key", "?")
+    # Start following log file
+    next(loglines)
+    return _filter_destructions(loglines)
+
+
+class RequestsCounter(dict):
+    """Amount of requests that went to hosts (with Elliptics node)."""
+
+    TransCheckerParams = namedtuple('TransCheckerParams', ["logged_destructions",
+                                                           "case",
+                                                           "checked_delay",
+                                                           "checked_delay_expected_time"])
+
+    def __init__(self, checker_params):
+        self._checker_params = checker_params
+        super(RequestsCounter, self).__init__()
+
+    def _check_trans_time(self):
+        """Checks READ transaction time."""
+        params = self._checker_params
+        destruction_record = next(params.logged_destructions)
+
+        print("{}".format(json.dumps(destruction_record, indent=4)))
+
+        host = destruction_record["st"].split(":")[0]
+        if params.case[host]["delay"] == params.checked_delay and \
+           int(destruction_record["time"]) > params.checked_delay_expected_time:
+            raise OvertimeError("READ transaction is overtimed")
+
+    def __getitem__(self, key):
+        # if the key is not in items, then set it's value to 0
+        try:
+            super(RequestsCounter, self).__getitem__(key)
+        except KeyError:
+            self.__setitem__(key, 0, check=False)
+
+        return super(RequestsCounter, self).__getitem__(key)
+
+    def __setitem__(self, key, value, check=True):
+        if check:
+            self._check_trans_time()
+        super(RequestsCounter, self).__setitem__(key, value)
+
+
+def do_requests(session, key, requests_number, trans_checker_params):
+    """Does specified amount of READ requests and returns distribution of these
+    requests.
+    """
+    requests_count = RequestsCounter(trans_checker_params)
+
+    for _ in xrange(requests_number):
+        result = session.read_data(key).get().pop()
+        requests_count[result.address.host] += 1
+
+    return requests_count
+
+
+def stabilizing_requests(session, key, requests_count, retry_max, trans_checker_params):
+    """Does specified amount of requests to stabilize weights."""
+    print("trying to stabilize weights")
+    retry_number = 0
+    while retry_number < retry_max:
+        try:
+            do_requests(session, key, requests_count, trans_checker_params)
+        except OvertimeError as exc:
+            logger.info("Failed to stabilize weights - retrying: {}\n".format(exc.message))
+            retry_number += 1
+        else:
+            return
+    raise RuntimeError("Retries count ({}) exceeded while was trying to stabilize weights."
+                       .format(retry_number))

--- a/tests/elliptics/mix-states/mix_states_utils.py
+++ b/tests/elliptics/mix-states/mix_states_utils.py
@@ -63,8 +63,6 @@ class RequestsCounter(dict):
         params = self._checker_params
         destruction_record = next(params.logged_destructions)
 
-        print("{}".format(json.dumps(destruction_record, indent=4)))
-
         host = destruction_record["st"].split(":")[0]
         if params.case[host]["delay"] == params.checked_delay and \
            int(destruction_record["time"]) > params.checked_delay_expected_time:
@@ -100,7 +98,6 @@ def do_requests(session, key, requests_number, trans_checker_params):
 
 def stabilizing_requests(session, key, requests_count, retry_max, trans_checker_params):
     """Does specified amount of requests to stabilize weights."""
-    print("trying to stabilize weights")
     retry_number = 0
     while retry_number < retry_max:
         try:

--- a/tests/elliptics/mix-states/test_mix_states.py
+++ b/tests/elliptics/mix-states/test_mix_states.py
@@ -126,8 +126,10 @@ def requests_count(case, session, key):
     statistics = defaultdict(int)
     data_samples_collected = 0
     retry_number = 0
-    # Prepare parameters to check a READ-transaction time
+    # Get iterable with logged records about desctructions READ transactions
+    # from these records we will get information about transaction taken time
     logged_destructions = mix_states_utils.get_logged_destructions(session, LOG_FILE)
+    # Prepare parameters to check a READ-transaction time
     trans_checker_params = RequestsCounter.TransCheckerParams(logged_destructions, case,
                                                               LOW_DELAY, LOW_DELAY_EXPECTED_TIME)
 

--- a/tests/elliptics/mix-states/test_mix_states.py
+++ b/tests/elliptics/mix-states/test_mix_states.py
@@ -82,7 +82,7 @@ def key(session):
     return key
 
 
-@pytest.fixture(scope='module', params=["+++++-"])
+@pytest.fixture(scope='module', params=["------", "+-----", "+++++-"])
 def case(request, nodes, create_schedulers):
     """Returns test cases.
 

--- a/tests/elliptics/mix-states/test_mix_states.py
+++ b/tests/elliptics/mix-states/test_mix_states.py
@@ -131,17 +131,21 @@ def requests_count(case, session, key):
     trans_checker_params = RequestsCounter.TransCheckerParams(logged_destructions, case,
                                                               LOW_DELAY, LOW_DELAY_EXPECTED_TIME)
 
+    # Stabilize weights
+    mix_states_utils.do_requests_with_retry(session, key, STABILIZE_REQUESTS_COUNT,
+                                            STABILIZING_RETRY_NUMBER_MAX, trans_checker_params)
+
     while retry_number < STATISTICS_RETRY_NUMBER_MAX and \
           data_samples_collected < SAMPLES_COUNT:
-        # Stabilize weight before sample
-        mix_states_utils.do_requests_with_retry(session, key, STABILIZE_REQUESTS_COUNT,
-                                                STABILIZING_RETRY_NUMBER_MAX, trans_checker_params)
-
         sample = mix_states_utils.do_requests_with_retry(session, key, SAMPLE_REQUESTS_COUNT,
                                                          1, trans_checker_params)
 
         if sample is None:
             retry_number += 1
+            # Stabilize weights
+            mix_states_utils.do_requests_with_retry(session, key, STABILIZE_REQUESTS_COUNT,
+                                                    STABILIZING_RETRY_NUMBER_MAX,
+                                                    trans_checker_params)
         else:
             # Collecting statistics
             for host, requests_count in sample.items():


### PR DESCRIPTION
- test_mix_states ignores long (in time) responses
  (external problems (networking problems, hardware problems and etc.) must be
  ignored - this test is not testing things like this)
- logging level was fixed
  (for elliptics v2.26)
- logger messages were corrected for `test_helper.network` module

reviewers: @uvizhe
