### PR TITLE
compatibility tests were moved to the end of test queue

### DIFF
--- a/configs/system-tests/test_different-versions.cfg
+++ b/configs/system-tests/test_different-versions.cfg
@@ -15,5 +15,6 @@
 	"setup_playbook": "tests/setup-different-versions-test",
 	"teardown_playbook": "tests/teardown-different-versions-test"
     },
+    "order": "trylast",
     "tags": ["system", "different-versions", "testing-packages", "pull-request"]
 }


### PR DESCRIPTION
Обновил запускатор (он научился запускать тесты в некотором порядке ).
Тесты совместимости толкнул в конец "очереди" тестов.
