### PR TITLE
fix: for setup-recovery-test playbook

### DIFF
--- a/ansible/install-elliptics.yml
+++ b/ansible/install-elliptics.yml
@@ -22,17 +22,5 @@
 
 - hosts: servers
   sudo: yes
-  tasks:
-    - name: Create logging directories
-      file: path={{ elliptics_dir }}/{{ log_dir }} state=directory
-
-    - name: Create data and history directories
-      file: path={{ elliptics_dir }}/{{ item[0] }}/{{ item[1] }} state=directory
-      with_nested:
-        - "[{% for i in range(backends_number) %} {{ i }} {% if not loop.last %},{% endif %} {% endfor %}]"
-        - ["{{ data_dir }}", "{{ hist_dir }}"]
-
-    - name: Create data file
-      file: path={{ elliptics_dir }}/{{ item }}/{{ data_dir }}/data state=touch
-      with_items:
-        - "[{% for i in range(backends_number) %} {{ i }} {% if not loop.last %},{% endif %} {% endfor %}]"
+  roles:
+    - create-elliptics-directories

--- a/ansible/roles/create-elliptics-directories/tasks/main.yml
+++ b/ansible/roles/create-elliptics-directories/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Create logging directories
+  file: path={{ elliptics_dir }}/{{ log_dir }} state=directory
+
+- name: Create data and history directories
+  file: path={{ elliptics_dir }}/{{ item[0] }}/{{ item[1] }} state=directory
+  with_nested:
+    - >
+        [{% for i in range(backends_number) %}
+          {{ i }} {% if not loop.last %},{% endif %}
+        {% endfor %}]
+    - ["{{ data_dir }}", "{{ hist_dir }}"]
+
+- name: Create data file
+  file: path={{ elliptics_dir }}/{{ item }}/{{ data_dir }}/data state=touch
+  with_items:
+    - >
+        [{% for i in range(backends_number) %}
+          {{ i }} {% if not loop.last %},{% endif %}
+        {% endfor %}]

--- a/ansible/tests/setup-recovery-test.yml
+++ b/ansible/tests/setup-recovery-test.yml
@@ -1,21 +1,13 @@
 ---
 - hosts: servers
+  sudo: yes
   tasks:
-    - name: Wipe out Elliptics data
-      file: path={{ item }} state=absent
-      with_items:
-        - "{{ log_dir }}"
-        - "{{ data_dir }}"
-        - "{{ hist_dir }}"
+    - name: Wipe out Elliptics directory
+      file: path={{ elliptics_dir }} state=absent
 
-    - name: Recreate necessary directories
-      file: path={{ item }} state=directory
-      with_items:
-        - "{{ log_dir }}"
-        - "{{ data_dir }}"
-        - "{{ hist_dir }}"
-
-    - name: Create data file
-      file: path={{ data_dir }}/data state=touch
+- hosts: servers
+  sudo: yes
+  roles:
+    - ../roles/create-elliptics-directories
 
 - include: ../elliptics-start.yml


### PR DESCRIPTION
Не обновил playbook-setup для тестов восстановления, после изменения работы с директориями Эллиптикса.
Теперь он обновлен + работа с директориями делается в специальной роле, а не в разных местах.

reviewers: @uvizhe
