### PR TITLE
recovery with dump_file option test was moved

### DIFF
--- a/configs/system-tests/test_real_cluster_recovery_dc_dump_file_option.cfg
+++ b/configs/system-tests/test_real_cluster_recovery_dc_dump_file_option.cfg
@@ -30,5 +30,6 @@
         "setup_playbook": "tests/setup-real-cluster-recovery-dc",
         "teardown_playbook": "tests/teardown-real-cluster-recovery-dc"
     },
+    "order": "trylast",
     "tags": ["real-cluster"]
 }


### PR DESCRIPTION
Тест падает с `MemoryError` - ставим его в конец очереди тестирования.

reviewers: @uvizhe
