### PR TITLE
fix: cache tests were updated

### DIFF
--- a/configs/system-tests/test_cache-lru.cfg
+++ b/configs/system-tests/test_cache-lru.cfg
@@ -3,7 +3,8 @@
 	"cache_size": 10000000,
 	"cache_numbers": 1,
 	"cache_pages_proportions": [1, 1],
-	"cache_sync_timeout": 3600
+	"cache_sync_timeout": 3600,
+	"backends_number": 1
     },
     "test_env_cfg": {
         "clients": {

--- a/configs/system-tests/test_cache-overhead.cfg
+++ b/configs/system-tests/test_cache-overhead.cfg
@@ -1,7 +1,8 @@
 {
     "params": {
         "cache_size": 16000000,
-        "cache_sync_timeout": 3600
+        "cache_sync_timeout": 3600,
+        "backends_number": 1
     },
     "test_env_cfg": {
         "clients": {


### PR DESCRIPTION
Для тестов кэша задаются специальные параметры, которые зависят от количества backend'ов.
Чтобы параметры соответствовали оригинальным тестам, выставил кол-во backend'ов для этих тестов в **1**.

reviewers: @uvizhe
