### PR TITLE
configuration file was updated:

### DIFF
--- a/ansible/templates/elliptics.json.j2
+++ b/ansible/templates/elliptics.json.j2
@@ -10,7 +10,10 @@
 	"sink": {
 	  "type": "files",
 	  "path": "{{ log_file_path }}",
-	  "autoflush": true
+	  "autoflush": true,
+	  "rotation": {
+	    "move": 0
+	  }
 	}
       }
     ]


### PR DESCRIPTION
There is a mandatory section in config file now: `rotation`. It allows to use
automatic log file archiving (log rotation) feature from Blackhole logging
library.

reviewers: @uvizhe
