### PR TITLE
Collecting backtraces as artifacts was added.

### DIFF
--- a/ansible/collect-artifacts.yml
+++ b/ansible/collect-artifacts.yml
@@ -30,7 +30,7 @@
         gdb
         -ex "thread apply all bt"
         -batch
-        -p {{ pgrep.stdout }}
+        -p {{ pidof.stdout }}
         >
         {{ backtraces_dump_file_path }}
       when: stop_nodes.get("failed", 0) == 1

--- a/ansible/collect-artifacts.yml
+++ b/ansible/collect-artifacts.yml
@@ -21,6 +21,27 @@
         dest={{ artifacts_collecting_dir }}/{{ ansible_hostname }}.conf
         flat=yes
 
+    - name: Create a file for backtraces
+      file: dest={{ backtraces_dump_dir }} state=directory
+      when: stop_nodes.get("failed", 0) == 1
+
+    - name: Dump backtraces to a file
+      shell: >
+        gdb
+        -ex "thread apply all bt"
+        -batch
+        -p {{ pgrep.stdout }}
+        >
+        {{ backtraces_dump_file_path }}
+      when: stop_nodes.get("failed", 0) == 1
+      ignore_errors: yes
+
+    - name: Copy dump file with backtraces
+      fetch:
+        src={{ backtraces_dump_file_path }}
+        dest={{ artifacts_collecting_dir }}/{{ ansible_hostname }}.bt.dump
+        flat=yes
+
 - hosts: clients
   tasks:
     - name: Copy client log

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -62,3 +62,5 @@ fastcgi_daemon_name: fastcgi-daemon2
 # test artifacts parameters
 artifacts_collecting_dir: /tmp/artifacts-collecting
 artifacts_dir: /tmp/test-artifacts
+backtraces_dump_dir: /tmp/elliptics
+backtraces_dump_file_path: "{{ backtraces_dump_dir }}/backtraces.dump"

--- a/ansible/roles/install-elliptics-from-repo/tasks/main.yml
+++ b/ansible/roles/install-elliptics-from-repo/tasks/main.yml
@@ -7,5 +7,7 @@
     --assume-yes
     --force-yes
     elliptics={{ elliptics_version }}
+    elliptics-dbg={{ elliptics_version }}
     elliptics-client={{ elliptics_version }}
     eblob={{ eblob_version }}
+    eblob-dbg={{ eblob_version }}

--- a/ansible/tests/teardown-test.yml
+++ b/ansible/tests/teardown-test.yml
@@ -3,18 +3,18 @@
   sudo: yes
   tasks:
     - name: Get process id
-      shell: pgrep dnet_ioserv
-      register: pgrep
+      shell: pidof dnet_ioserv
+      register: pidof
       ignore_errors: yes
 
     - name: Stop Elliptics daemon
-      shell: kill {{ pgrep.stdout }}
+      shell: kill {{ pidof.stdout }}
       register: kill
       ignore_errors: yes
-      when: pgrep.rc == 0
+      when: pidof.rc == 0
 
     - name: Wait for Elliptics to stop
-      shell: while [ -e /proc/{{ pgrep.stdout }} ]; do sleep 0.1; done
+      shell: while [ -e /proc/{{ pidof.stdout }} ]; do sleep 0.1; done
       register: stop_nodes
       when: kill.get("rc", 3) == 0
       ignore_errors: yes

--- a/ansible/tests/teardown-test.yml
+++ b/ansible/tests/teardown-test.yml
@@ -2,21 +2,24 @@
 - hosts: servers
   sudo: yes
   tasks:
-    - name: Getting process id
+    - name: Get process id
       shell: pgrep dnet_ioserv
       register: pgrep
       ignore_errors: yes
 
     - name: Stop Elliptics daemon
-      shell: pkill dnet_ioserv
+      shell: kill {{ pgrep.stdout }}
+      register: kill
       ignore_errors: yes
+      when: pgrep.rc == 0
 
     - name: Wait for Elliptics to stop
       shell: while [ -e /proc/{{ pgrep.stdout }} ]; do sleep 0.1; done
       register: stop_nodes
+      when: kill.get("rc", 3) == 0
       ignore_errors: yes
       async: 45
-      poll: 5
+      poll: 1
 
 - include: ../collect-artifacts.yml
 


### PR DESCRIPTION
Now, when `dnet_ioserv` process failed to stop, backtraces for all threads will
be collected as test artifacts.

reviewers: @uvizhe
