### PR TITLE
Routing table acceptance tests were added and some small changes

### DIFF
--- a/ansible/collect-artifacts.yml
+++ b/ansible/collect-artifacts.yml
@@ -44,11 +44,11 @@
 
 - hosts: clients
   tasks:
-    - name: Copy client log
-      fetch:
-        src={{ client_log }}
-        dest={{ artifacts_collecting_dir }}/{{ ansible_hostname }}.log
-        flat=yes
+    - name: Copy test logs
+      synchronize:
+        mode=pull
+        src="{{ test_logs_path }}/*"
+        dest="{{ artifacts_collecting_dir }}/{{ ansible_hostname }}-test-logs/"
       ignore_errors: yes
 
     - name: Copy recovery dc log
@@ -72,4 +72,4 @@
     - name: zip files
       shell: >
         cd {{ artifacts_collecting_dir }};
-        zip {{ artifacts_dir }}/test-{{ test_name }}.zip `ls ./`;
+        zip -r {{ artifacts_dir }}/test-{{ test_name }}.zip ./;

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -32,8 +32,8 @@ backends_number: 3
 blob_flags: 6
 blob_sync: -1
 
-# Client parameters
-client_log: /var/log/elliptics/client.log
+# Test parameters
+test_logs_path: /var/log/elliptics_testing
 
 # dnet_recovery parameters
 recovery_dc_dir: /var/tmp/dnet_recovery_dc/

--- a/ansible/tests/setup-test.yml
+++ b/ansible/tests/setup-test.yml
@@ -5,3 +5,8 @@
     - ../roles/create-elliptics-directories
 
 - include: ../elliptics-start.yml
+
+- hosts: clients
+  tasks:
+    - name: Create client logging directory
+      file: path={{ test_logs_path }} state=directory

--- a/ansible/tests/teardown-test.yml
+++ b/ansible/tests/teardown-test.yml
@@ -35,7 +35,7 @@
     - name: Wipe out client and recovery logs
       file: path={{ item }} state=absent
       with_items:
-        - "{{ client_log }}"
+        - "{{ test_logs_path }}"
         - "{{ recovery_dc_dir }}"
         - "{{ recovery_merge_dir }}"
 

--- a/configs/elliptics/test_routing-table.cfg
+++ b/configs/elliptics/test_routing-table.cfg
@@ -1,0 +1,18 @@
+{
+    "params": {
+        "check_timeout": 10
+    },
+    "test_env_cfg": {
+        "clients": {
+            "count": 1,
+            "flavor": "m1.small"
+        },
+        "servers": {
+            "count_per_group": [3],
+            "flavor": "m1.small"
+        },
+	"setup_playbook": "tests/setup-test",
+	"teardown_playbook": "tests/teardown-test"
+    },
+    "tags": ["routing-table"]
+}

--- a/configs/elliptics/test_routing-table.cfg
+++ b/configs/elliptics/test_routing-table.cfg
@@ -14,5 +14,5 @@
 	"setup_playbook": "tests/setup-test",
 	"teardown_playbook": "tests/teardown-test"
     },
-    "tags": ["routing-table"]
+    "tags": ["routing-table", "pull-request", "testing-packages"]
 }

--- a/configs/elliptics/test_routing-table.run
+++ b/configs/elliptics/test_routing-table.run
@@ -1,0 +1,5 @@
+{
+    "type": "pytest",
+    "target": "elliptics/routing-table",
+    "addopts": "{% for node in servers %} --node={{ node.host }}:{{ node.port }}:{{ node.group }}{% endfor %} --backends-number=3 --check-timeout={{ check_timeout }}"
+}

--- a/lib/test_helper/elliptics_testhelper.py
+++ b/lib/test_helper/elliptics_testhelper.py
@@ -92,7 +92,7 @@ class EllipticsTestHelper(elliptics.Session):
             'AddrNotExists': "No such device or address"
             })
 
-    _log_path = "/var/log/elliptics/client.log"
+    _log_path = "/var/log/elliptics_testing/client.log"
     
     DROP_RULES = ["INPUT --proto tcp --destination-port {port} --jump DROP",
                   "INPUT --proto tcp --source-port {port} --jump DROP",

--- a/lib/test_helper/logger.ini
+++ b/lib/test_helper/logger.ini
@@ -19,7 +19,7 @@ propagate = 0
 
 [handler_consoleHandler]
 class = StreamHandler
-level = DEBUG
+level = ERROR
 formatter = generalFormatter
 args = (sys.stdout,)
 

--- a/lib/test_helper/network.py
+++ b/lib/test_helper/network.py
@@ -3,7 +3,13 @@
 import subprocess
 import shlex
 
+from test_helper import ssh
 from test_helper.logging_tests import logger
+
+DROP_RULES = ["INPUT --proto tcp --destination-port {port} --jump DROP",
+              "INPUT --proto tcp --source-port {port} --jump DROP",
+              "OUTPUT --proto tcp --destination-port {port} --jump DROP",
+              "OUTPUT --proto tcp --source-port {port} --jump DROP"]
 
 
 def add_scheduler(host):
@@ -25,3 +31,29 @@ def del_scheduler(host):
     cmd = "ssh -q {} tc qdisc del dev eth0 root netem delay 0ms".format(host)
     subprocess.check_call(shlex.split(cmd))
     logger.info("A scheduler for network emulator was removed for host: {}\n".format(host))
+
+
+def drop_node(node):
+    """Drops specified node through firewall."""
+    sshclient = ssh.get_sshclient(node.host)
+    for drop_rule in DROP_RULES:
+        rule = drop_rule.format(port=node.port)
+        cmd = "iptables --append {rule}".format(host=node.host, rule=rule)
+
+        stdin, stdout, stderr = sshclient.exec_command(cmd)
+
+        ssh.wait_for_command(cmd, stderr)
+        logger.info("{}: {}\n".format(node.host, cmd))
+
+
+def resume_node(node):
+    """Resumes specified node through firewall."""
+    sshclient = ssh.get_sshclient(node.host)
+    for drop_rule in DROP_RULES:
+        rule = drop_rule.format(port=node.port)
+        cmd = "iptables --delete {rule}".format(host=node.host, rule=rule)
+
+        stdin, stdout, stderr = sshclient.exec_command(cmd)
+
+        ssh.wait_for_command(cmd, stderr)
+        logger.info("{}: {}\n".format(node.host, cmd))

--- a/lib/test_helper/ssh.py
+++ b/lib/test_helper/ssh.py
@@ -1,0 +1,55 @@
+import paramiko
+import os
+import os.path
+import time
+
+
+def _get_sshconfig(config_path="~/.ssh/config"):
+    config_full_path = os.path.abspath(os.path.expanduser(config_path))
+    sshconf = paramiko.SSHConfig()
+    sshconf.parse(open(config_full_path))
+    return sshconf
+
+
+def _recv_all_stderr(ssh_channel):
+    buffer_len = 1024
+    stderr = ""
+    buff = ssh_channel.recv_stderr(buffer_len)
+    while buff:
+        stderr += buff
+        buff = ssh_channel.recv_stderr(buffer_len)
+    return stderr
+
+
+def wait_for_command(cmd, stderr):
+    """Wait for command to complete."""
+    while not stderr.channel.exit_status_ready():
+        time.sleep(0.1)
+
+    if stderr.channel.exit_status:
+        stderr_output = _recv_all_stderr(stderr.channel)
+        raise RuntimeError("Got an error:\n"
+                           "Command: {}\n"
+                           "Exit status: {}\n"
+                           "stderr:\n{}".format(cmd, stderr.channel.exit_status, stderr_output))
+
+
+def get_sshclient(host):
+    """Returns ssh client connected to specified host."""
+    # Set logging for ssh client
+    ssh_logging_file_path = "/var/log/elliptics_testing/ssh.log"
+    dir_path = os.path.dirname(ssh_logging_file_path)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    paramiko.util.log_to_file(ssh_logging_file_path)
+
+    sshclient = paramiko.SSHClient()
+    sshclient.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    sshconf = _get_sshconfig()
+    host_ssh_settings = sshconf.lookup(host)
+    private_key = host_ssh_settings["identityfile"]
+
+    sshclient.connect(host, key_filename=private_key)
+
+    return sshclient

--- a/lib/test_helper/utils.py
+++ b/lib/test_helper/utils.py
@@ -3,16 +3,58 @@
 import hashlib
 import random
 import inspect
-import importlib                                                                          
+import importlib
+import elliptics
+import os.path
+import os
+import socket
 
 from os import urandom
+
 
 KB = 1 << 10
 MB = 1 << 20
 
+
 MIN_LENGTH = 10*KB
 MAX_LENGTH = 10*MB
 USER_FLAGS_MAX = 2**64 - 1
+
+
+def get_nodes_from_option(node_option):
+    """Returns list of nodes from command line options."""
+    nodes = [Node(*node_str.split(':'))
+             for node_str in node_option]
+    return nodes
+
+
+def create_session(nodes, check_timeout=None, wait_timeout=None, test_name="test"):
+    """Returns elliptics session."""
+    log_dir_path = "/var/log/elliptics_testing"
+    log_path = "{}/client-{}.log".format(log_dir_path, test_name)
+    if not os.path.exists(log_dir_path):
+        os.makedirs(log_dir_path)
+    elog = elliptics.Logger(log_path, elliptics.log_level.debug)
+
+    config = elliptics.Config()
+    if wait_timeout:
+        config.wait_timeout = wait_timeout
+    if check_timeout:
+        config.check_timeout = check_timeout
+
+    client_node = elliptics.Node(elog, config)
+    addresses = [elliptics.Address(node.host, node.port, socket.AF_INET)
+                 for node in nodes]
+    client_node.add_remotes(addresses)
+
+    elliptics_session = elliptics.Session(client_node)
+
+    # Get uniq groups from nodes list
+    groups = list({node.group for node in nodes})
+    elliptics_session.groups = groups
+
+    return elliptics_session
+
 
 def get_data(size=MAX_LENGTH, randomize_len=True):
     """ Returns a string of random bytes

--- a/lib/test_helper/utils.py
+++ b/lib/test_helper/utils.py
@@ -21,6 +21,26 @@ MAX_LENGTH = 10*MB
 USER_FLAGS_MAX = 2**64 - 1
 
 
+class Client(object):
+    """Clients object for testing needs."""
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def __repr__(self):
+        return "Client({host}, {port})".format(**self.__dict__)
+
+
+class Node(object):
+    def __init__(self, host, port, group):
+        self.host = host
+        self.port = int(port)
+        self.group = int(group)
+
+    def __repr__(self):
+        return "Node({0}, {1}, {2})".format(self.host, self.port, self.group)
+
+
 def get_nodes_from_option(node_option):
     """Returns list of nodes from command line options."""
     nodes = [Node(*node_str.split(':'))
@@ -64,41 +84,27 @@ def get_data(size=MAX_LENGTH, randomize_len=True):
     data = urandom(size)
     return data
 
+
 def get_sha1(data):
     m = hashlib.sha1()
     m.update(data)
     return m.hexdigest()
+
 
 def get_key_and_data(size=MAX_LENGTH, randomize_len=True):
     data = get_data(size, randomize_len)
     key = get_sha1(data)
     return (key, data)
 
+
 def get_key_and_data_list(list_size=3):
     data_list = []
-    for i in range(list_size):
+    for _ in range(list_size):
         data_list.append(get_data())
     key = get_sha1(''.join(data_list))
 
     return key, data_list
 
-class Client(object):
-    """Clients object for testing needs."""
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-
-    def __repr__(self):
-        return "Client({host}, {port})".format(**self.__dict__)
-
-class Node(object):
-    def __init__(self, host, port, group):
-        self.host = host
-        self.port = int(port)
-        self.group = int(group)
-
-    def __repr__(self):
-        return "Node({0}, {1}, {2})".format(self.host, self.port, self.group)
 
 def _get_testcases_items(testcases_module_name):
     testcases_module = importlib.import_module(testcases_module_name)
@@ -106,8 +112,10 @@ def _get_testcases_items(testcases_module_name):
         if inspect.getmodule(func) == testcases_module:
             yield func_name, func
 
+
 def get_testcases(testcases_module_name):
     return [testcase for _, testcase in _get_testcases_items(testcases_module_name)]
+
 
 def get_testcases_names(testcases_module_name):
     return [testcase_name for testcase_name, _ in _get_testcases_items(testcases_module_name)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,41 +4,26 @@ import elliptics
 import socket
 
 from test_helper.elliptics_testhelper import nodes
+from test_helper import utils
 
 
 def pytest_addoption(parser):
     parser.addoption('--node', type='string', action='append', dest="nodes",
                      help="Elliptics node. Example: --node=hostname:port:group")
-    parser.addoption('--wait-timeout', type='int', dest="wait_timeout",
-                     help="Elliptics wait_timeout.")
-    parser.addoption('--check-timeout', type='int', dest="check_timeout",
-                     help="Elliptics check_timeout.")
+    parser.addoption('--wait-timeout', type=int, help="Elliptics wait_timeout.")
+    parser.addoption('--check-timeout', type=int, help="Elliptics check_timeout.")
 
 
 @pytest.fixture(scope='module')
-def session(pytestconfig, nodes):
+def nodes(request):
+    """Returns list of nodes."""
+    return utils.get_nodes_from_option(request.config.option.nodes)
+
+
+@pytest.fixture(scope='function')
+def session(request, nodes):
     """Returns prepared elliptics.Session."""
-    log_path = "/var/log/elliptics/client.log"
-    dir_path = os.path.dirname(log_path)
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
-    elog = elliptics.Logger(log_path, elliptics.log_level.debug)
-
-    config = elliptics.Config()
-    if pytestconfig.option.wait_timeout:
-        config.wait_timeout = pytestconfig.option.wait_timeout
-    if pytestconfig.option.check_timeout:
-        config.check_timeout = pytestconfig.option.check_timeout
-
-    client_node = elliptics.Node(elog, config)
-    addresses = [elliptics.Address(node.host, node.port, socket.AF_INET)
-                 for node in nodes]
-    client_node.add_remotes(addresses)
-
-    elliptics_session = elliptics.Session(client_node)
-
-    # Get uniq groups from nodes list
-    groups = list({n.group for n in nodes})
-    elliptics_session.groups = groups
-
-    return elliptics_session
+    return utils.create_session(nodes,
+                                request.config.option.check_timeout,
+                                request.config.option.wait_timeout,
+                                request.node.name)

--- a/tests/elliptics/mix-states/test_mix_states.py
+++ b/tests/elliptics/mix-states/test_mix_states.py
@@ -13,7 +13,7 @@ from test_helper.elliptics_testhelper import nodes
 from test_helper.logging_tests import logger
 
 # Logging file for elliptics client
-LOG_FILE = "elliptics_client.log"
+LOG_FILE = "/var/log/elliptics_testing/elliptics_client.log"
 # Data length for key which will be used for test requests
 DATA_LENGTH = 1
 # Networking delays

--- a/tests/elliptics/routing-table/conftest.py
+++ b/tests/elliptics/routing-table/conftest.py
@@ -1,0 +1,2 @@
+def pytest_addoption(parser):
+    parser.addoption("--backends-number", type=int, help="number of backends.")

--- a/tests/elliptics/routing-table/routing_table_utils.py
+++ b/tests/elliptics/routing-table/routing_table_utils.py
@@ -95,7 +95,7 @@ def _get_routes_upper_bound(routing_entries):
 
 
 def _get_routes_lower_bound(routing_entries):
-    """Returns routes entry with upper bound ID (000000...000000)."""
+    """Returns routes entry with lower bound ID (000000...000000)."""
     lower_routing_entry = min(routing_entries, key=_routing_entry_key)
     if str(lower_routing_entry.id) == _ID_LOWER_BOUND:
         lower_bound = copy.deepcopy(lower_routing_entry)

--- a/tests/elliptics/routing-table/routing_table_utils.py
+++ b/tests/elliptics/routing-table/routing_table_utils.py
@@ -1,0 +1,179 @@
+import elliptics
+import socket
+import binascii
+import time
+import random
+import pytest
+import copy
+
+from abc import ABCMeta, abstractmethod
+from hamcrest import assert_that, has_items, has_length
+
+from test_helper import ssh
+from test_helper import network
+from test_helper import utils
+
+
+_ID_LEN = 64
+_ID_UPPER_BOUND = "ff" * _ID_LEN
+_ID_LOWER_BOUND = "00" * _ID_LEN
+
+
+class AbstractTestRoutingTableEntries(object):
+    """Base test class for routing table acceptance tests."""
+    __metaclass__ = ABCMeta
+
+    @pytest.fixture(scope='class')
+    def session(self, request, nodes):
+        """Returns elliptics session."""
+        return utils.create_session(nodes,
+                                    request.config.option.check_timeout,
+                                    request.config.option.wait_timeout,
+                                    request.node.name)
+
+    @abstractmethod
+    @pytest.fixture(scope='class')
+    def routing_entries(self, nodes, request):
+        pass
+
+    def test_contains_necessary_entries(self, session, routing_entries):
+        """Checks that client node's routing table contains all necessary entires.
+
+        Client node's routing table must contain entries about it remote nodes and their
+        remotes.
+
+        """
+        assert_that(session.routes, has_items(*routing_entries),
+                    "client node doesn't have all necessary routing table entries")
+
+    def test_contains_boundary_entries(self, session, routing_entries):
+        """Checks that client node's routing table contains boundary entries.
+
+        Client node's routing table must contain boundary entries, which was inserted by
+        client node itself. These entires have following IDs:
+
+          * 000000...000000;
+          * ffffff...ffffff.
+
+        """
+        upper_bound_entry = _get_routes_upper_bound(routing_entries)
+        lower_bound_entry = _get_routes_lower_bound(routing_entries)
+
+        assert_that(session.routes, has_items(upper_bound_entry, lower_bound_entry),
+                    "client node doesn't have routing table entires with boundary IDs")
+
+    def test_only_necessary_entries(self, session, routing_entries):
+        """Checks that client node's routing table contains only necessary entries.
+
+        Client node's routing table must have only following entries:
+
+          * entries about it remotes;
+          * entries about remotes of client node's remotes;
+          * entries with boundary IDs.
+
+        """
+        entries_differance = [entry for entry in session.routes
+                              if entry not in routing_entries and
+                                 str(entry.id) != _ID_UPPER_BOUND and
+                                 str(entry.id) != _ID_LOWER_BOUND]
+
+        assert_that(entries_differance, has_length(0),
+                    "client node has some extra routing table entries")
+
+
+def _routing_entry_key(routing_entry):
+    """Key function for sorting `elliptics.Route` objects."""
+    return routing_entry.id
+
+
+def _get_routes_upper_bound(routing_entries):
+    """Returns routes entry with upper bound ID (ffffff...ffffff)."""
+    upper_routing_entry = max(routing_entries, key=_routing_entry_key)
+    upper_bound = copy.deepcopy(upper_routing_entry)
+    upper_bound.id = elliptics.Id.from_hex(_ID_UPPER_BOUND)
+    return upper_bound
+
+
+def _get_routes_lower_bound(routing_entries):
+    """Returns routes entry with upper bound ID (000000...000000)."""
+    lower_routing_entry = min(routing_entries, key=_routing_entry_key)
+    if str(lower_routing_entry.id) == _ID_LOWER_BOUND:
+        lower_bound = copy.deepcopy(lower_routing_entry)
+    else:
+        # If ID != 000000...000000, then interval [000000...00000; MIN_ID) must belong
+        # to node-backend with maximum ID
+        upper_routing_entry = max(routing_entries, key=_routing_entry_key)
+        lower_bound = copy.deepcopy(upper_routing_entry)
+    lower_bound.id = elliptics.Id.from_hex(_ID_LOWER_BOUND)
+    return lower_bound
+
+
+def wait_stall_counter(session, node):
+    """Waits untill stall counter reaches `stall_count`."""
+    STALL_COUNT = 3
+    address = elliptics.Address(node.host, node.port, socket.AF_INET)
+
+    async_results = []
+    for _ in xrange(STALL_COUNT):
+        async_results.append(session.request_backends_status(address))
+        # Wait a bit, to count these transaction separatly for stall counter
+        time.sleep(1)
+
+    # Wait for completion of all transactions
+    for async_result in async_results:
+        try:
+            async_result.wait()
+        except elliptics.Error:
+            pass
+
+
+def drop_half_nodes(nodes, session):
+    """Disables half nodes through a firewall."""
+    dropped_nodes_count = (len(nodes) + 1) / 2
+    dropped_nodes_result = random.sample(nodes, dropped_nodes_count)
+
+    for node in dropped_nodes_result:
+        network.drop_node(node)
+        # Wait when connections to nodes will be terminated
+        wait_stall_counter(session, node)
+
+    return dropped_nodes_result
+
+
+def _str_to_ids(ids_string):
+    """Converts string contant of ids file to `elliptics.Id` objects."""
+    # Split all elliptics id
+    ids_str = [ids_string[i:i+_ID_LEN] for i in xrange(0, len(ids_string), _ID_LEN)]
+    # Get actual elliptics.Id objects
+    ids_hex = [binascii.hexlify(id_str) for id_str in ids_str]
+    ids = [elliptics.Id.from_hex(id_hex) for id_hex in ids_hex]
+    return ids
+
+
+def _get_routes_from_ids(node, backends_number, history_path="/mnt/elliptics/history"):
+    """Returns routing table entries for specified node."""
+    sshclient = ssh.get_sshclient(node.host)
+    sftp = sshclient.open_sftp()
+    address = elliptics.Address(node.host, node.port, socket.AF_INET)
+
+    routes = []
+    for backend_id in xrange(backends_number):
+        # Get content of ids file
+        ids_path = "{}/{}/ids".format(history_path, backend_id)
+        ids_file = sftp.open(ids_path)
+        ids = _str_to_ids(ids_file.read())
+
+        backend_routes = [elliptics.Route(elliptics_id, address, backend_id)
+                          for elliptics_id in ids]
+
+        routes.extend(backend_routes)
+
+    return routes
+
+
+def get_routes_for_nodes(nodes, backends_number):
+    """Returns routing table entries for all specified nodes."""
+    routing_entries = [routing_entry
+                       for node in nodes
+                       for routing_entry in _get_routes_from_ids(node, backends_number)]
+    return routing_entries

--- a/tests/elliptics/routing-table/test_routing_table.py
+++ b/tests/elliptics/routing-table/test_routing_table.py
@@ -1,0 +1,115 @@
+"""Routing table acceptance tests."""
+
+import pytest
+import random
+import time
+
+from test_helper import network
+from test_helper import utils
+from test_helper.logging_tests import logger
+
+from routing_table_utils import (get_routes_for_nodes, drop_half_nodes,
+                                 AbstractTestRoutingTableEntries)
+
+
+class TestAddingAtStart(AbstractTestRoutingTableEntries):
+    """Test case for adding routing table entries at starting node."""
+
+    @pytest.fixture(scope='class')
+    def routing_entries(self, request, nodes):
+        """Returns routing table entries.
+
+        At starting node must have entries about all it remotes.
+
+        """
+        return get_routes_for_nodes(nodes, request.config.option.backends_number)
+
+
+class TestRemovingAfterNodeDrop(AbstractTestRoutingTableEntries):
+    """Test case for removing routing table entries after dropping nodes."""
+
+    @pytest.fixture(scope='class')
+    def dropped_nodes(self, request, nodes, session):
+        """Returns list of dropped nodes.
+
+        This fixture drops half nodes and returns a list of these nodes. After tests, for
+        this test case, the fixture resumes all dropped nodes.
+
+        """
+        dropped_nodes_result = drop_half_nodes(nodes, session)
+
+        def resume_nodes():
+            for node in dropped_nodes_result:
+                network.resume_node(node)
+
+        request.addfinalizer(resume_nodes)
+
+        return dropped_nodes_result
+
+    @pytest.fixture(scope='class')
+    def routing_entries(self, request, nodes, dropped_nodes):
+        """Returns routing table entries.
+
+        After dropping some nodes entries about these nodes must be removed and routing
+        table must contain entries only about available nodes.
+
+        """
+        available_nodes = [node for node in nodes if node not in dropped_nodes]
+        return get_routes_for_nodes(available_nodes, request.config.option.backends_number)
+
+
+class TestAddingAfterNodeResume(AbstractTestRoutingTableEntries):
+    """Test case for adding routing table entries after resuming nodes."""
+
+    @pytest.fixture(scope='class')
+    def resumed_nodes(self, request, nodes, session):
+        """Returns list of resumed nodes.
+
+        This fixture drops half node, then resume them and returns list of these nodes.
+
+        """
+        result_nodes = drop_half_nodes(nodes, session)
+
+        for node in result_nodes:
+            network.resume_node(node)
+
+        wait_time = request.config.option.check_timeout + 1
+        logger.info("Wait {} seconds for routing table update...".format(wait_time))
+        time.sleep(wait_time)
+
+        return result_nodes
+
+    @pytest.fixture(scope='class')
+    def routing_entries(self, request, nodes, resumed_nodes):
+        """Returns routing table entries.
+
+        After resuming nodes there must be entires about all nodes in routing table.
+
+        """
+        return get_routes_for_nodes(nodes, request.config.option.backends_number)
+
+
+class TestAddingAtUpdate(AbstractTestRoutingTableEntries):
+    """Test case for adding routing table entries at updating routing table."""
+
+    @pytest.fixture(scope='class')
+    def all_nodes(self, request):
+        """Returns list of all nodes."""
+        return utils.get_nodes_from_option(request.config.option.nodes)
+
+    @pytest.fixture(scope='class')
+    def nodes(self, all_nodes):
+        """Returns list of client node's remotes."""
+        return [random.choice(all_nodes)]
+
+    @pytest.fixture(scope='class')
+    def routing_entries(self, request, all_nodes):
+        """Returns routing table entries.
+
+        After updating routing table there must be entries about all nodes:
+
+          * entries about client node's remotes;
+          * entries about remotes of client node's remotes.
+
+        """
+        return get_routes_for_nodes(all_nodes, request.config.option.backends_number)

--- a/tests/system-tests/different-versions/test_versions.py
+++ b/tests/system-tests/different-versions/test_versions.py
@@ -24,7 +24,7 @@ def new_nodes(pytestconfig):
 @pytest.fixture(scope='function')
 def new_client_node():
     """Returns client node for elliptics v2.26."""
-    log_path = "/var/log/elliptics/new_client.log"
+    log_path = "/var/log/elliptics_testing/new_client.log"
     dir_path = os.path.dirname(log_path)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
@@ -61,7 +61,7 @@ def old_nodes(pytestconfig):
 @pytest.fixture(scope='function')
 def old_client_node():
     """Returns client node for elliptics v2.25."""
-    log_path = "/var/log/elliptics/old_client.log"
+    log_path = "/var/log/elliptics_testing/old_client.log"
     dir_path = os.path.dirname(log_path)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)


### PR DESCRIPTION
- function for creating `elliptics.Session` can be invoked to logging in
  specific file
  (it allow each test to have separate logging file)
- logging level for `consoleHandler` was changed to **ERROR**
  (`consoleHandler` is a default handler, which can be used (with inheritance,
  for example) by anyone, and it is bad idea to set it's logging level to change
  your own handler's (which inherit `consoleHandler`) logging level)
- `drop`/`resume_node` functions were added to `test_helper.network` module
  (`EllipticsTestHelper.drop_node` and `EllipticsTestHelper.resume_node` are
  depricated and will be removed)
- `ssh` module was added to `test_helper` package
  (it is a bad practice to use shell commands through python, and all new tests
  should use this module to execute SSH commands on remote hosts; this module
  uses `paramiko` - python SSH module)
- `nodes` fixture was added to global `conftest.py` file
  (`nodes` fixture from `test_helper.elliptics_testhelper` is depricated;
  importing fixtures is a bad idea, when it can be placed in `conftest.py` file)

**reviewer**: @uvizhe
