### PR TITLE
Compatibility tests were updated with fixed v2.25 version.

### DIFF
--- a/configs/system-tests/test_different-versions.cfg
+++ b/configs/system-tests/test_different-versions.cfg
@@ -1,6 +1,6 @@
 {
     "params": {
-	"elliptics_old_version": "2.25.6.10",
+	"elliptics_old_version": "2.25.6.13",
 	"eblob_old_version": "0.22.0"
     },
     "test_env_cfg": {


### PR DESCRIPTION
A bug with unabling to terminate `dnet_ioserv` (v2.25) with **SIGTERM**, when
v2.26-nodes were trying to connect to v2.25-nodes was fixed in v2.25.6.13.

reviewers: @uvizhe
