### PR TITLE
Wrong pytest's scopes were fixed.

### DIFF
--- a/tests/elliptics/recovery/dc/test_recovery_dc.py
+++ b/tests/elliptics/recovery/dc/test_recovery_dc.py
@@ -59,10 +59,10 @@ import elliptics
 
 from hamcrest import assert_that, calling, raises, equal_to, is_not
 
+from test_helper import utils
 from test_helper.elliptics_testhelper import nodes
-from test_helper.utils import get_testcases, get_testcases_names, get_sha1
 
-from ..utils.testrecovery import AbstractTestRecovery
+from recovery.utils.testrecovery import AbstractTestRecovery
 
 
 class TestRecoveryDC(AbstractTestRecovery):
@@ -83,7 +83,7 @@ class TestRecoveryDC(AbstractTestRecovery):
                             "{} key is not accessible after recovery operation in node, "
                             "where it must be accessible.".format(keys_type))
                 
-                data_hash = get_sha1(async_read.get()[0].data)
+                data_hash = utils.get_sha1(async_read.get()[0].data)
 
                 assert_that(data_hash, equal_to(key),
                             "{} key's data mismatch after recovery operation.".format(keys_type))
@@ -103,7 +103,7 @@ class TestRecoveryDC(AbstractTestRecovery):
                                   if index in key_indexes])
         return expected_keys
     
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='class')
     def dropped(self, pytestconfig, session):
         """Returns a list of dropped groups."""
         if pytestconfig.option.dropped_groups_path:
@@ -130,9 +130,9 @@ class TestRecoveryDC(AbstractTestRecovery):
 
         return session
 
-    @pytest.fixture(scope='module',
-                    params=get_testcases("recovery.dc.testcases"),
-                    ids=get_testcases_names("recovery.dc.testcases"))
+    @pytest.fixture(scope='class',
+                    params=utils.get_testcases("recovery.dc.testcases"),
+                    ids=utils.get_testcases_names("recovery.dc.testcases"))
     def recovery(self, pytestconfig, request, session, nodes, indexes, dropped):
         """Returns a structure of recovery data."""
         recovery_result = super(TestRecoveryDC, self).recovery(pytestconfig,

--- a/tests/elliptics/recovery/merge/test_recovery_merge.py
+++ b/tests/elliptics/recovery/merge/test_recovery_merge.py
@@ -61,10 +61,10 @@ import socket
 
 from hamcrest import assert_that, calling, raises, equal_to, is_not
 
+from test_helper import utils
 from test_helper.elliptics_testhelper import nodes
-from test_helper.utils import get_testcases, get_testcases_names, get_sha1
 
-from ..utils.testrecovery import AbstractTestRecovery
+from recovery.utils.testrecovery import AbstractTestRecovery
 
 
 class TestRecoveryMerge(AbstractTestRecovery):
@@ -84,7 +84,7 @@ class TestRecoveryMerge(AbstractTestRecovery):
                         "{} key is not accessible after recovery operation in node, "
                         "where it must be accessible.".format(keys_type))
 
-            data_hash = get_sha1(async_read.get()[0].data)
+            data_hash = utils.get_sha1(async_read.get()[0].data)
 
             assert_that(data_hash, equal_to(key),
                         "{} key's data mismatch after recovery operation.".format(keys_type))
@@ -101,7 +101,7 @@ class TestRecoveryMerge(AbstractTestRecovery):
                                   if index in key_indexes])
         return expected_keys
 
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='class')
     def dropped(self, nodes):
         """Returns a list of dropped nodes."""
         nodes_count = len(nodes)
@@ -128,9 +128,9 @@ class TestRecoveryMerge(AbstractTestRecovery):
 
         return session
 
-    @pytest.fixture(scope='module',
-                    params=get_testcases("recovery.merge.testcases"),
-                    ids=get_testcases_names("recovery.merge.testcases"))
+    @pytest.fixture(scope='class',
+                    params=utils.get_testcases("recovery.merge.testcases"),
+                    ids=utils.get_testcases_names("recovery.merge.testcases"))
     def recovery(self, pytestconfig, request, session, nodes, indexes, dropped):
         """Returns a structure of recovery data."""
         recovery_result = super(TestRecoveryMerge, self).recovery(pytestconfig,

--- a/tests/elliptics/recovery/utils/testrecovery.py
+++ b/tests/elliptics/recovery/utils/testrecovery.py
@@ -12,6 +12,7 @@ import elliptics
 from abc import ABCMeta, abstractmethod
 from hamcrest import assert_that, equal_to
 
+from test_helper import utils
 from test_helper.logging_tests import logger
 from test_helper.matchers import hasitem
 
@@ -46,7 +47,15 @@ class AbstractTestRecovery(object):
     def get_expected_keys(self, recovery, group, index, dropped):
         pass
     
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='class')
+    def session(self, request, nodes):
+        """Returns elliptics session."""
+        return utils.create_session(nodes,
+                                    request.config.option.check_timeout,
+                                    request.config.option.wait_timeout,
+                                    request.node.name)
+
+    @pytest.fixture(scope='class')
     def indexes(self):
         """Returns randomly generated indexes."""
         indexes_count = 5
@@ -59,12 +68,12 @@ class AbstractTestRecovery(object):
         pass
 
     @abstractmethod
-    @pytest.fixture(scope='function')
+    @pytest.fixture(scope='class')
     def dropped(self):
         pass
 
     @abstractmethod
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='class')
     def recovery(self, pytestconfig, request, session, nodes, indexes, dropped):
         recovery_result = request.param(pytestconfig.option, session, nodes, dropped, indexes)
 


### PR DESCRIPTION
After changing scope for fixture `session` recovery tests were not updated.
These tests had an assumption: global fixture `session` has **module** scope,
but this is a bad assumption, 'cause shared fixtures lead to erratic tests and
global fixtures (if it's something not static - like `session` object) should
have **function** scope (and be a Fresh Fixture).

reviewers: @uvizhe
