### PR TITLE
Fixed running tests as a user.

### DIFF
--- a/ansible/tests/setup-different-versions-test.yml
+++ b/ansible/tests/setup-different-versions-test.yml
@@ -2,6 +2,7 @@
 - hosts:
     - servers
     - clients
+  sudo: yes
   tasks:
     - name: Install elliptics (old version)
       apt: >
@@ -17,6 +18,7 @@
 - hosts: servers
   vars:
     old_elliptics_config: templates/elliptics-v2.25.json.j2
+  sudo: yes
   tasks:
     - name: Create Elliptics config file
       template: >
@@ -26,6 +28,7 @@
         dest={{ config_file_path }}
 
 - hosts: servers
+  sudo: yes
   tasks:
     - name: Start Elliptics daemon
       command: dnet_ioserv -c {{ config_file_path }}
@@ -35,3 +38,12 @@
 
     - name: Ensure Elliptics is running
       shell: ps ax | grep [d]net_ioserv
+
+- hosts: clients
+  sudo: yes
+  tasks:
+    - name: Create client logging directory
+      file:
+        path={{ test_logs_path }}
+        state=directory
+        owner={{ ansible_ssh_user }}

--- a/ansible/tests/setup-test.yml
+++ b/ansible/tests/setup-test.yml
@@ -7,6 +7,10 @@
 - include: ../elliptics-start.yml
 
 - hosts: clients
+  sudo: yes
   tasks:
     - name: Create client logging directory
-      file: path={{ test_logs_path }} state=directory
+      file:
+        path={{ test_logs_path }}
+        state=directory
+        owner={{ ansible_ssh_user }}

--- a/tests/timeouts-tests/test_timeouts.py
+++ b/tests/timeouts-tests/test_timeouts.py
@@ -11,6 +11,7 @@ import test_helper.elliptics_testhelper as et
 import test_helper.utils as utils
 from test_helper.elliptics_testhelper import key_and_data, nodes
 from test_helper.utils import MB
+from test_helper import network
 
 @pytest.fixture(scope='function')
 def client(pytestconfig, nodes):
@@ -29,10 +30,10 @@ def write_and_drop_node(request, client, key_and_data):
     key, data = key_and_data
     result = client.write_data_sync(key, data).pop()
     node = result.storage_address
-    client.drop_node(node)
+    network.drop_node(node)
 
     def teardown():
-        client.resume_node(node)
+        network.resume_node(node)
 
     request.addfinalizer(teardown)
     return client, key
@@ -61,7 +62,7 @@ def write_with_quorum_check(request, client, key_and_data):
     and starts data writing
     """
     # Data size depends on WAIT_TIMEOUT and networking limitations
-    # (see elliptics_testhelper.set_networking_limitations()).
+    # (see network.set_networking_limitations()).
     # Change this value depend on your network connection.
     size = 6*MB
 
@@ -70,11 +71,11 @@ def write_with_quorum_check(request, client, key_and_data):
 
     client.set_checker(elliptics.checkers.quorum)
 
-    et.set_networking_limitations()
+    network.set_networking_limitations()
     res = client.write_data(key, data)
 
     def teardown():
-        et.clear_networking_limitations()
+        network.clear_networking_limitations()
 
     request.addfinalizer(teardown)
     
@@ -88,11 +89,11 @@ def quorum_checker_positive(request, nodes, write_with_quorum_check):
     dnodes = random.sample(nodes, dnodes_count)
 
     for node in dnodes:
-        client.drop_node(node)
+        network.drop_node(node)
 
     def teardown():
         for node in dnodes:
-            client.resume_node(node)
+            network.resume_node(node)
 
     request.addfinalizer(teardown)
 
@@ -115,11 +116,11 @@ def quorum_checker_negative(request, nodes, write_with_quorum_check):
     dnodes = random.sample(nodes, dnodes_count)
     
     for node in dnodes:
-        client.drop_node(node)
+        network.drop_node(node)
 
     def teardown():
         for node in dnodes:
-            client.resume_node(node)
+            network.resume_node(node)
 
     request.addfinalizer(teardown)
 
@@ -164,10 +165,10 @@ def write_and_shuffling_off(request, client_shuffling_off, nodes, key_and_data):
     groups = random.sample(client.get_groups(), 2)
     node = filter(lambda n: n.group == groups[0], nodes)[0]
 
-    client.drop_node(node)
+    network.drop_node(node)
     
     def teardown():
-        client.resume_node(node)
+        network.resume_node(node)
 
     request.addfinalizer(teardown)
 


### PR DESCRIPTION
- Added missed `sudo` in playbooks.
- Added logging directory creation for compatibility test suite.
- Added setting owner for logging directory.
  (There are two logging directories in tests: directory for `dnet_ioserv`
  process and directory for client. The first one is used by a root process and
  the second one is used by client process which is running as test-user (from
  `--user` option of `running/runtests.py`))
- Added missed `sudo` for `test_helper.network` module's functions.
- Get rid of depricated networking functions.
  (Replaced `drop_node`, `resume_node`, `resume_all_nodes` methods of
  `EllipticsTestHelper` from `test_helper.elliptics_testhelper` with proper
  functions of `test_helper.network` module and removed those methods. Moved
  `set_networking_limitations` and `clear_networking_limitations` from
  `test_helper.elliptics_testhelper` to `test_helper.network`)

reviewers: @uvizhe
